### PR TITLE
Feature/skills, claudemd and helper function updates

### DIFF
--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -133,7 +133,7 @@ Point to the right skill for what the engineer wants to do:
 ## Gotchas
 
 - OAuth MUST use `Content-Type: application/x-www-form-urlencoded`, not JSON
-- Tokens expire mid-session — re-authenticate silently from `.env` on auth errors
+- Tokens expire mid-session — on any 401/403, re-authenticate silently: read credentials from `{use-case}/.env` or `environments/*.env`, call the auth endpoint, update `.auth.json` with the new token, and retry the failed request. Never prompt the user for credentials if `.env` exists.
 - OpenAPI spec is ~1.5MB — search locally with `jq`, never load into context
 - `tasks/list` `app` field has WRONG casing for adapters — use `apps/list` for correct names
 - Devices endpoint is POST not GET — body required

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,9 @@ Requirements  →  Feasibility  →  Design  →  Build  →  As-Built
 21. **Duplicate transition keys to same target** — JSON doesn't allow two keys with the same name. If a task needs both `success` and `error` to reach `workflow_end`, create an error handler task (e.g., `newVariable` to set error status) and route error there, then route that task to `workflow_end`.
 22. **Respect task schema data types** — When wiring task inputs, match the type from `task-schemas.json` exactly. If a field is typed as `array`, pass an array (e.g., `["joksan@example.com"]`), not a bare string. If typed as `number`, pass a number, not a string. Common offenders: `to`/`cc`/`bcc` in email tasks (arrays, not strings), `pageSize`/`page` in queries (numbers, not strings). Mismatched types cause silent failures or validation errors.
 23. **Adapter `app` ≠ adapter instance name** — The `app` and `locationType` fields on adapter tasks must be the adapter **type name** from `apps.json` (e.g., `EmailOpensource`, `Servicenow`), NOT the adapter **instance name** from `adapters.json` (e.g., `email`, `servicenow-prod`). Using the instance name causes `"No config found for Adapter: <name>"` at runtime. The `adapter_id` field is where the instance name goes. Triple-check: `app` = type, `adapter_id` = instance.
+24. **Project-scoped asset names** — once an asset is added to a project, its `name` is prefixed with `@{projectId}: `. When updating via PUT, you MUST include this prefix or the API returns 400. Read the asset first to get the scoped name, or construct it as `@{projectId}: {displayName}`.
+25. **Check task output variable names from schema** — don't guess camelCase vs snake_case. Common gotcha: `renderJinjaTemplate` outputs `renderedTemplate` (camelCase), not `rendered_template`. Always fetch the schema and check `variables.outgoing` keys before wiring.
+
 
 ## Helper JSON Templates
 

--- a/helpers/workflow-task-adapter.json
+++ b/helpers/workflow-task-adapter.json
@@ -6,6 +6,7 @@
   "location": "Adapter",
   "locationType": "",
   "app": "",
+  "adapter_id":"",
   "type": "automatic",
   "displayName": "",
   "variables": {


### PR DESCRIPTION
## Description

It updates information for the claudemd on project scoped asset names.
Adds a skill to re-auth smoothly without prompting user for credentials again
Update helper function for adapter task to include adapter_id as a field.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

## Changes Made

Update `AGENTS.md` to always track asset names and while pushing new assets to existing projects, always use `@{projectId}: {displayName}` in order for the PUT call to not fail.
Update helper file `helpers/workflow-task-adapter.json` to include `adapter_id` as one of the fields in the adapter task json.
Update `SKILL.md` to track and read credentials silently while trying to reauth in case of expred tokens mid-session. Make sure to never prompt the user for the credentials if a .env exists

## Testing

Tested successfully locally and pushing assets to `https://ws-solution-design-poc-iap01.trial.itential.io/` successfully. Screenshots attached

<img width="1601" height="473" alt="image" src="https://github.com/user-attachments/assets/1a2c1b30-65ad-4d01-81af-92dbafbdd487" />

<img width="1615" height="630" alt="image" src="https://github.com/user-attachments/assets/76ed95a9-717b-420c-b8a2-67b682d4ad6c" />

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code has been commented where necessary
- [ ] Tested with `make setup` or relevant profile
- [ ] Commits follow conventional format (`type: subject`)
- [ ] No secrets or credentials committed
- [ ] Documentation has been updated accordingly
- [ ] PR has been labeled appropriately (`enhancement`, `bug`, `documentation`, `refactor`, `chore`)