### PR TITLE
docs: add WFE/platform gotchas from real-world build experience

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -291,6 +291,9 @@ If both success and error need to reach `workflow_end`, route error to an interm
 - [ ] Every adapter task has `adapter_id` in incoming
 - [ ] Every adapter task has an error transition
 - [ ] `evaluation` tasks have both success AND failure transitions
+- [ ] `evaluation` operators are from the closed enum (`contains, !contains, <, <=, >, >=, ==, !=`) — no others exist
+- [ ] `evaluation` `operand_2` literal values containing regex metacharacters (`.`, `(`, `)`, `[`, `]`, `?`, `+`, `*`, `|`) are properly escaped, OR stored in a `newVariable` constant-holder task to avoid `incomingRefs` cache issues after API PUT
+- [ ] No `$var.<taskId>.<out>` references inside nested forEach bodies — use `$var.job.<varName>` instead
 - [ ] Incoming variable types match task schema exactly (arrays for `to`/`cc`/`bcc`, numbers for `page`/`pageSize`, etc.)
 - [ ] No `$var` references inside nested objects (use merge/makeData)
 - [ ] merge uses `"variable"`, childJob uses `"value"`
@@ -1194,6 +1197,25 @@ Conditional branching. **MUST have BOTH success AND failure transitions.**
 **Outgoing:** `return_value` (boolean)
 **Transitions:** `success` (true), `failure` (false)
 
+**Operator enum — closed set. Only these 8 are valid:**
+```
+contains, !contains, <, <=, >, >=, ==, !=
+```
+`regex`, `match`, `matches`, `contains_key`, `in`, `startsWith` — **do not exist**. An invalid operator silently returns `false` with empty outgoing and `finish_state: failure`. No error message. Always validate against this list before wiring. Source of truth: `openapi.json` at `components/schemas/workflow_engine_wfEngineCommon_evaluationItem/properties/operator/enum`.
+
+**`contains` is regex-based, not substring.** `operand_2` is interpreted as a regex pattern. A literal like `9.2(4)` is parsed as regex — `.` matches any char, `(4)` becomes a capture group — and may match unintended strings or fail to match the intended one. Escape regex metacharacters in literal patterns: `9\.2\(4\)` not `9.2(4)`.
+
+**`contains` also works for object-key presence** — it is the universal "does X contain Y" operator. On a string operand it does regex matching; on an object operand it tests key presence. There is no separate `contains_key` operator.
+
+**Direct evaluation test (no workflow needed):**
+```
+POST /workflow_engine/runEvaluationGroups
+{"evaluation_groups":[{"operator":"AND","evaluations":[{"operand_1":"<test input>","operator":"contains","operand_2":"<pattern>"}]}]}
+```
+Returns `true`/`false`. Invalid operators silently return `false`. Use this to validate operators and escape patterns before wiring them into a workflow.
+
+**`incomingRefs` cache — API PUT does not regenerate it.** Evaluation operand resolution is cached in `incomingRefs` per task. `PUT /automation-studio/automations/{uid}` persists the JSON but **does NOT regenerate `incomingRefs`**. After a PUT, evaluation operands that reference literal values or changed taskRefs may resolve to `null` at runtime. Signs of a stale cache: evaluation returns `false` despite correct-looking JSON; `GET /operations-manager/tasks/{iterationUUID}` shows `incomingRefs[n].taskId: null` or `taskPointer: "/variables/outgoing/undefined"`. Fix: open the workflow in the UI and save to force regeneration. **API-only workaround:** store all `operand_2` constants in a dedicated `newVariable` task (e.g., `k_result`) and reference via `{"task": "k_result", "variable": "value"}` — taskRef resolution is not affected by the cache.
+
 **Operand reference format (uses `"variable"`, same as merge):**
 - `{"task": "job", "variable": "varName"}`
 - `{"task": "static", "variable": "literalValue"}`
@@ -1280,6 +1302,8 @@ forEach --state:loop--> firstBodyTask -> ... -> lastBodyTask --(empty {})
 forEach --state:success--> nextTaskAfterLoop
 ```
 The last task in the loop body has an **empty transition `{}`**. Do NOT connect it back to forEach.
+
+**Nested forEach — `$var.<taskId>.<output>` does NOT resolve inside nested loop bodies.** String references like `$var.n01.current_item` silently resolve to `null` when used inside an inner forEach body. Use `$var.job.<varName>` (the forEach's outgoing job variable binding) instead. This applies to all reference styles — even taskRef objects `{"task": "outerTask", "variable": "current_item"}` are unreliable inside a nested body. Always bind forEach outputs to job variables and reference those inside nested bodies.
 
 ### newVariable
 
@@ -1866,6 +1890,15 @@ The `revert` transition moves execution back to a previous task, allowing the us
 32. **`stringConcat` doesn't resolve `$var` in `stringN` arrays** — use merge → makeData with `<!var!>` placeholders instead.
 33. **`legacyWrapper: false` on Operations Manager manual triggers** — default `true` wraps form values under `formData`, breaking variable mapping.
 34. **Always use a local venv for Python** — run `python3 -m venv .venv && source .venv/bin/activate` instead of using global Python when running any Python scripts during the build process.
+35. **`evaluation` operator is a closed enum** — only `contains, !contains, <, <=, >, >=, ==, !=` exist. Any other operator silently returns `false` with empty outgoing. See the `evaluation` task section for the full enum and testing endpoint.
+36. **`contains` operator uses regex, not substring matching** — escape metacharacters (`(`, `)`, `.`, `[`, `]`, `?`, `+`, `*`, `|`) in literal `operand_2` values. Test patterns with `POST /workflow_engine/runEvaluationGroups` before wiring.
+37. **API PUT does not regenerate `incomingRefs`** — evaluation operand literals left stale after PUT silently resolve to `null`. Always verify evals work after an API-only deploy; if they silently fail, open the workflow in the UI and save. See `evaluation` task section for the API-only constant-holder workaround.
+38. **`$var.<taskId>.<out>` does not resolve inside nested forEach bodies** — use `$var.job.<varName>` for any variable referenced inside a nested loop body.
+39. **Search `tasks.json` before designing any sub-workflow** — grep for keywords matching the intent (e.g., `filter`, `inventory`, `tag`) before building client-side logic. A platform task may already exist that does the work server-side more efficiently.
+40. **Prefer server-side filtering over client-side when available** — fetching the full collection and filtering in the workflow adds unnecessary iterations and complexity. Check whether the target application exposes a filtered-fetch task before designing a forEach + evaluation filter pattern.
+41. **Propose decomposition when a workflow exceeds ~20 tasks** — large flat workflows are hard to test and debug in isolation. If the design calls for more than ~20 tasks, offer a decomposed alternative: extract the inner iteration body into a reusable child workflow and call it via childJob.
+42. **DRY check on sibling workflows** — if building multiple similarly-named workflows, compare their task graphs before generating. If the task graphs are identical, flag it and propose a single generic workflow; don't silently generate N identical clones.
+43. **GatewayManager `"failed to parse start_time"` = device unreachable** — this IAG error (`"failed to parse start_time for command 0: failed to parse timestamp string ''"`) means the device is offline, unreachable, or authentication failed. The timestamp complaint is misleading — the session never opened. It is NOT a workflow bug or command syntax error. Guard with an `evaluation` checking whether the response contains a `result` key; if not, route to a skip handler and continue.
 
 ---
 
@@ -1911,3 +1944,4 @@ These are complete, tested workflows. Read them to understand how tasks connect,
 | childJob with evaluation (parent orchestrator) | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-parent-workflow.json` | childJob → query → evaluation pattern for checking child success/failure |
 | merge → makeData pattern | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-merge-makedata.json` | Building template variables with merge, then string substitution with makeData |
 | Child with makeData/query/merge | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-child-workflow.json` | Data transformation patterns inside a child workflow |
+| Per-device sendCommand scan | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-sendcommand-workflow.json` | buildInventoryFilter → forEach → newVariable+push array build → sendCommand → response guard → pattern match → matched/errored/skipped classification. Demonstrates constant-holder pattern for evaluation operands and `$var.job.*` usage inside loop body. |

--- a/helpers/reference-sendcommand-workflow.json
+++ b/helpers/reference-sendcommand-workflow.json
@@ -1,0 +1,611 @@
+{
+  "_comment": "Reference: per-device sendCommand scan with inventory filter, response guard, and error classification. Teaches the newVariable+push array-build pattern, the constant-holder pattern for evaluation operands, and the response-contains-result guard. Adapt task IDs, commands, and match patterns to your use case.",
+  "automation": {
+    "name": "Reference - sendCommand Per-Device Scan",
+    "description": "Filters an inventory by tag, iterates devices, runs a show command via GatewayManager.sendCommand, evaluates the output against a pattern, and classifies results into matched/errored/skipped lists.",
+    "type": "automation",
+    "canvasVersion": 3,
+    "font_size": 12,
+    "tasks": {
+      "workflow_start": {
+        "name": "workflow_start",
+        "groups": [],
+        "nodeLocation": { "x": 200, "y": 600 }
+      },
+
+      "k_result": {
+        "_comment": "Constant-holder: stores the string 'result' so evaluation operand_2 resolves via taskRef rather than a literal. Avoids incomingRefs cache staleness after API PUT.",
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Constant: 'result'",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "k_result_val", "value": "result" },
+          "outgoing": { "value": "$var.job.k_result_val" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 500, "y": 600 }
+      },
+
+      "i01": {
+        "_comment": "Initialize accumulator lists for matched, errored, and skipped devices.",
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Init matched list",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "matched", "value": [] },
+          "outgoing": { "value": "$var.job.matched" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 800, "y": 600 }
+      },
+
+      "i02": {
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Init errored list",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "errored", "value": [] },
+          "outgoing": { "value": "$var.job.errored" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 800, "y": 732 }
+      },
+
+      "i03": {
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Init skipped list",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "skipped", "value": [] },
+          "outgoing": { "value": "$var.job.skipped" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 800, "y": 864 }
+      },
+
+      "f01": {
+        "_comment": "Filter inventory by tag server-side. Output is [{inventory, nodeNames}] — same shape sendCommand expects for its inventory field.",
+        "name": "buildInventoryFilter",
+        "canvasName": "buildInventoryFilter",
+        "summary": "Filter inventory by tag",
+        "location": "Application",
+        "locationType": null,
+        "app": "InventoryManager",
+        "type": "operation",
+        "displayName": "InventoryManager",
+        "variables": {
+          "incoming": {
+            "inventoryIdentifiers": "$var.job.inventory_names",
+            "tagIdentifiers": "$var.job.tag_filter",
+            "tagMatchType": "any",
+            "outputFormat": "compact"
+          },
+          "outgoing": { "filter_result": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 1100, "y": 600 }
+      },
+
+      "q01": {
+        "_comment": "Extract the nodeNames array from the first filter result item.",
+        "name": "query",
+        "canvasName": "query",
+        "summary": "Extract node names",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "query": "[0].nodeNames",
+            "obj": "$var.job.filter_result",
+            "pass_on_null": false
+          },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 1400, "y": 600 }
+      },
+
+      "n01": {
+        "_comment": "forEach over the filtered node list. current_item is each node name.",
+        "name": "forEach",
+        "canvasName": "forEach",
+        "summary": "Iterate nodes",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "data_array": "$var.job.node_names" },
+          "outgoing": { "current_item": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 1700, "y": 600 }
+      },
+
+      "b01": {
+        "_comment": "Build command_array: newVariable + push because sendCommand requires an array even for a single command. Inline array literals do not resolve $var at runtime.",
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Init command array",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "command_array", "value": [] },
+          "outgoing": { "value": "$var.job.command_array" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 2000, "y": 600 }
+      },
+
+      "b02": {
+        "name": "push",
+        "canvasName": "push",
+        "summary": "Push command string",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "value": "$var.job.show_command",
+            "array": "command_array"
+          },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 2300, "y": 600 }
+      },
+
+      "b03": {
+        "_comment": "Build node_name_array for this iteration. sendCommand.inventory[].nodeNames must be an array.",
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Init node name array",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "node_name_array", "value": [] },
+          "outgoing": { "value": "$var.job.node_name_array" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 2600, "y": 600 }
+      },
+
+      "b04": {
+        "_comment": "Use $var.job.current_node_name (the job variable bound by forEach) — NOT $var.n01.current_item (taskId ref doesn't resolve inside loop body).",
+        "name": "push",
+        "canvasName": "push",
+        "summary": "Push current node name",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "value": "$var.job.current_node_name",
+            "array": "node_name_array"
+          },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 2900, "y": 600 }
+      },
+
+      "b05": {
+        "_comment": "Build the inventory entry object: {inventory, nodeNames}. merge requires 2+ items — pad with a semantically meaningful second field.",
+        "name": "merge",
+        "canvasName": "merge",
+        "summary": "Build inventory entry",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "data_to_merge": [
+              { "inventory": { "task": "job", "variable": "inventory_name" } },
+              { "nodeNames": { "task": "job", "variable": "node_name_array" } }
+            ]
+          },
+          "outgoing": { "merged_object": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 3200, "y": 600 }
+      },
+
+      "b06": {
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Init inventory array",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "inv_array", "value": [] },
+          "outgoing": { "value": "$var.job.inv_array" },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 3500, "y": 600 }
+      },
+
+      "b07": {
+        "name": "push",
+        "canvasName": "push",
+        "summary": "Push inventory entry",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "value": "$var.b05.merged_object",
+            "array": "inv_array"
+          },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 3800, "y": 600 }
+      },
+
+      "s01": {
+        "_comment": "sendCommand: per-device call. Must have error transition or job hangs if IAG cluster is unreachable.",
+        "name": "sendCommand",
+        "canvasName": "sendCommand",
+        "summary": "Run show command on device",
+        "location": "Application",
+        "locationType": null,
+        "app": "GatewayManager",
+        "type": "operation",
+        "displayName": "GatewayManager",
+        "variables": {
+          "incoming": {
+            "clusterId": "$var.job.cluster_id",
+            "commands": "$var.job.command_array",
+            "inventory": "$var.job.inv_array"
+          },
+          "outgoing": { "result": null, "status": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 4100, "y": 600 }
+      },
+
+      "e01": {
+        "_comment": "Guard: does the response contain a 'result' key? If not, device was unreachable (IAG 'failed to parse start_time' error — offline device, NOT a workflow bug). operand_2 references constant-holder k_result to avoid incomingRefs cache issues.",
+        "name": "evaluation",
+        "canvasName": "evaluation",
+        "summary": "Response contains result?",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "all_true_flag": true,
+            "evaluation_groups": [{
+              "all_true_flag": true,
+              "evaluations": [{
+                "operand_1": { "task": "s01", "variable": "result" },
+                "operator": "contains",
+                "operand_2": { "task": "k_result", "variable": "value" }
+              }]
+            }]
+          },
+          "outgoing": { "return_value": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 4400, "y": 600 }
+      },
+
+      "q02": {
+        "_comment": "Extract stdout from the first command result.",
+        "name": "query",
+        "canvasName": "query",
+        "summary": "Extract stdout",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "query": "result.results[0].output",
+            "obj": "$var.job.gw_result",
+            "pass_on_null": false
+          },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 4700, "y": 600 }
+      },
+
+      "e02": {
+        "_comment": "Match: does stdout contain the target pattern? 'contains' uses regex — escape metacharacters in match_pattern (e.g., '9\\.2\\(4\\)' not '9.2(4)'). Test with POST /workflow_engine/runEvaluationGroups before wiring.",
+        "name": "evaluation",
+        "canvasName": "evaluation",
+        "summary": "Stdout matches pattern?",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": {
+            "all_true_flag": true,
+            "evaluation_groups": [{
+              "all_true_flag": true,
+              "evaluations": [{
+                "operand_1": { "task": "job", "variable": "stdout" },
+                "operator": "contains",
+                "operand_2": { "task": "job", "variable": "match_pattern" }
+              }]
+            }]
+          },
+          "outgoing": { "return_value": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 5000, "y": 600 }
+      },
+
+      "p_matched": {
+        "name": "push",
+        "canvasName": "push",
+        "summary": "Push to matched list",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "value": "$var.job.current_node_name", "array": "matched" },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 5300, "y": 468 }
+      },
+
+      "p_skipped": {
+        "name": "push",
+        "canvasName": "push",
+        "summary": "Push to skipped list",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "value": "$var.job.current_node_name", "array": "skipped" },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 5300, "y": 600 }
+      },
+
+      "p_errored": {
+        "_comment": "Error path: sendCommand failed (IAG task error) or response had no result key (device unreachable).",
+        "name": "push",
+        "canvasName": "push",
+        "summary": "Push to errored list",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "value": "$var.job.current_node_name", "array": "errored" },
+          "outgoing": { "return_data": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 4400, "y": 732 }
+      },
+
+      "loop_end": {
+        "_comment": "All body paths converge here. Transition is empty {} — do NOT connect back to forEach.",
+        "name": "newVariable",
+        "canvasName": "newVariable",
+        "summary": "Loop body end marker",
+        "location": "Application",
+        "locationType": null,
+        "app": "WorkFlowEngine",
+        "type": "operation",
+        "displayName": "WorkFlowEngine",
+        "variables": {
+          "incoming": { "name": "_loop_end", "value": true },
+          "outgoing": { "value": null },
+          "error": "",
+          "decorators": []
+        },
+        "groups": [],
+        "actor": "Pronghorn",
+        "scheduled": false,
+        "nodeLocation": { "x": 5600, "y": 600 }
+      },
+
+      "workflow_end": {
+        "name": "workflow_end",
+        "groups": [],
+        "nodeLocation": { "x": 5900, "y": 600 }
+      }
+    },
+
+    "transitions": {
+      "workflow_start": { "k_result": { "type": "standard", "state": "success" } },
+      "k_result": { "i01": { "type": "standard", "state": "success" } },
+      "i01": { "i02": { "type": "standard", "state": "success" } },
+      "i02": { "i03": { "type": "standard", "state": "success" } },
+      "i03": { "f01": { "type": "standard", "state": "success" } },
+      "f01": { "q01": { "type": "standard", "state": "success" } },
+      "q01": { "n01": { "type": "standard", "state": "success" } },
+      "n01": {
+        "b01": { "type": "standard", "state": "loop" },
+        "workflow_end": { "type": "standard", "state": "success" }
+      },
+      "b01": { "b02": { "type": "standard", "state": "success" } },
+      "b02": { "b03": { "type": "standard", "state": "success" } },
+      "b03": { "b04": { "type": "standard", "state": "success" } },
+      "b04": { "b05": { "type": "standard", "state": "success" } },
+      "b05": { "b06": { "type": "standard", "state": "success" } },
+      "b06": { "b07": { "type": "standard", "state": "success" } },
+      "b07": { "s01": { "type": "standard", "state": "success" } },
+      "s01": {
+        "e01": { "type": "standard", "state": "success" },
+        "p_errored": { "type": "standard", "state": "error" }
+      },
+      "e01": {
+        "q02": { "type": "standard", "state": "success" },
+        "p_errored": { "type": "standard", "state": "failure" }
+      },
+      "q02": { "e02": { "type": "standard", "state": "success" } },
+      "e02": {
+        "p_matched": { "type": "standard", "state": "success" },
+        "p_skipped": { "type": "standard", "state": "failure" }
+      },
+      "p_matched": { "loop_end": { "type": "standard", "state": "success" } },
+      "p_skipped": { "loop_end": { "type": "standard", "state": "success" } },
+      "p_errored": { "loop_end": { "type": "standard", "state": "success" } },
+      "loop_end": {}
+    },
+
+    "groups": [],
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "inventory_name": { "title": "inventory_name", "type": "string", "description": "Inventory to scan (e.g. 'my-inventory')", "default": "" },
+        "inventory_names": { "title": "inventory_names", "type": "array", "description": "Array wrapper for inventory_name, passed to buildInventoryFilter", "default": [] },
+        "tag_filter": { "title": "tag_filter", "type": "array", "description": "Tag names to filter devices by (e.g. ['cisco_ios'])", "default": [] },
+        "cluster_id": { "title": "cluster_id", "type": "string", "description": "IAG cluster brokering device connections", "default": "" },
+        "show_command": { "title": "show_command", "type": "string", "description": "CLI command to run on each device (e.g. 'show version')", "default": "" },
+        "match_pattern": { "title": "match_pattern", "type": "string", "description": "Regex pattern to match against command stdout. Escape metacharacters: use '9\\.2\\(4\\)' not '9.2(4)'", "default": "" }
+      },
+      "required": ["inventory_name", "inventory_names", "tag_filter", "cluster_id", "show_command", "match_pattern"]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "matched": { "title": "matched", "type": "array", "description": "Devices where stdout matched the pattern" },
+        "errored": { "title": "errored", "type": "array", "description": "Devices that returned errors or were unreachable" },
+        "skipped": { "title": "skipped", "type": "array", "description": "Devices where stdout did not match the pattern" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **9 new gotchas** in `builder-agent/SKILL.md` covering evaluation operator semantics, `incomingRefs` cache behavior, nested forEach variable resolution, server-side filtering preference, workflow decomposition heuristic, DRY sibling check, and GatewayManager device-unreachable error signature
- **3 pre-submit checklist additions** for the new evaluation-specific rules
- **New reference helper** `reference-sendcommand-workflow.json` — complete per-device GatewayManager sendCommand scan pattern (inventory filter → forEach → array build → sendCommand → response guard → pattern match → matched/errored/skipped)

## Changes

### builder-agent/SKILL.md

**evaluation task section:**
- Operator closed enum documented (`contains, !contains, <, <=, >, >=, ==, !=` — anything else silently returns `false`)
- `contains` is regex-based, not substring — metachar escaping required
- `contains` doubles as object-key presence test (no `contains_key` operator exists)
- `runEvaluationGroups` direct test endpoint shown for validating operators/patterns without a full workflow run
- `incomingRefs` cache gap: API PUT doesn't regenerate it; constant-holder `newVariable` workaround documented

**forEach task section:**
- `$var.<taskId>.<output>` silently resolves to `null` inside nested loop bodies — must use `$var.job.<varName>`

**Pre-submit checklist:**
- Eval operator must be from closed enum
- Eval `operand_2` regex metacharacters must be escaped or constant-holder used
- No `$var.<taskId>` refs inside nested forEach bodies

**Gotchas (35–43):**
- 35–37: evaluation operator/regex/incomingRefs (cross-references to task section)
- 38: nested forEach `$var` resolution
- 39–40: search `tasks.json` first; prefer server-side filtering over forEach+evaluation
- 41: decompose when workflow exceeds ~20 tasks
- 42: DRY check on sibling workflows before generating identical clones
- 43: GatewayManager "failed to parse start_time" = device unreachable, not a workflow bug

### helpers/reference-sendcommand-workflow.json (new)

Complete per-device scan reference workflow demonstrating:
- `buildInventoryFilter` (tag-based, server-side) over `getNodesByInventory` + client-side filter
- `newVariable` + `push` array-build pattern (required because inline array literals don't resolve `$var`)
- Constant-holder task for evaluation `operand_2` to avoid `incomingRefs` staleness
- `$var.job.*` usage inside forEach body
- Response guard evaluation (checks for `result` key to detect unreachable devices)
- Three-bucket result classification: matched / errored / skipped

## Test plan

- [ ] Review gotcha wording for accuracy and platform-version neutrality
- [ ] Confirm `reference-sendcommand-workflow.json` JSON is valid (`jq . helpers/reference-sendcommand-workflow.json`)
- [ ] Confirm new checklist items don't conflict with existing ones
- [ ] Smoke-test: load `/builder-agent` skill and verify the evaluation section renders correctly

---

Signed-off-by: Joksan Flores <joksan.flores@itential.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
