### PR TITLE
fix: correct plugin marketplace name in install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The result is infrastructure automation that is traceable, repeatable, and deliv
 **Install the plugin:**
 
 ```bash
-/plugin install itential-builder@claude-plugins-official
+/plugin install itential-builder@itential-builder
 ```
 
 **Already installed? Update to the latest version:**
 
 ```bash
-/plugin update itential-builder@claude-plugins-official
+/plugin update itential-builder@itential-builder
 ```
 
 **First-time setup:**

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The result is infrastructure automation that is traceable, repeatable, and deliv
 **Install the plugin:**
 
 ```bash
+/plugin marketplace add itential/builder-skills
 /plugin install itential-builder@itential-builder
 ```
 


### PR DESCRIPTION
## Summary

- `/plugin install` and `/plugin update` commands in the README referenced `@claude-plugins-official` (Anthropic's official registry)
- `itential-builder` is not in that registry — it lives in the custom `@itential-builder` marketplace
- Users on a fresh machine get a "not found" error when following the documented install command

## Change

```diff
- /plugin install itential-builder@claude-plugins-official
+ /plugin install itential-builder@itential-builder

- /plugin update itential-builder@claude-plugins-official
+ /plugin update itential-builder@itential-builder
```

## Test plan

- [ ] Run `/plugin install itential-builder@itential-builder` on a machine without the plugin installed — confirms it resolves correctly
- [ ] Run `/plugin update itential-builder@itential-builder` on a machine with the plugin — confirms update works

🤖 Generated with [Claude Code](https://claude.com/claude-code)