### PR TITLE
feat: improve builder-agent skill and helpers

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -1444,6 +1444,17 @@ POST /template_builder/templates/{name}/renderJinja
 
 MOP manages command templates for running CLI commands with validation rules. **MOP is read-only validation only — never use it to push config.**
 
+**To push config to a device, use `itential_cli` via AGManager** — not MOP. The standard pattern for any config push delivery is:
+
+```
+Pre-Check (RunCommandTemplate child)
+  → Push Configuration to Device (renderJinjaTemplate → dry run approval → itential_cli → commit approval → itential_cli)
+  → Post-Check (RunCommandTemplate child)
+  → runTemplatesDiff (compare pre vs post)
+```
+
+Read `${CLAUDE_PLUGIN_ROOT}/helpers/reference-push-config-workflow.json` and `${CLAUDE_PLUGIN_ROOT}/helpers/reference-command-template-runner.json` before building any config push delivery.
+
 ### Create a Command Template
 
 ```
@@ -1856,7 +1867,7 @@ The `revert` transition moves execution back to a previous task, allowing the us
 24. **Eval types are case-sensitive** — `"RegEx"` not `"regex"`.
 25. **Empty rules = auto-pass** — add at least one rule for validation.
 26. **MOP update is full replacement** — include ALL fields.
-27. **MOP is read-only** — never use it to push config.
+27. **MOP is read-only** — never use it to push config. Use `itential_cli` via AGManager for config push.
 
 ### General
 28. **Adapter `app` must come from `apps.json`** — NOT `tasks.json` (names can differ completely).
@@ -1886,7 +1897,10 @@ Read these first. They have the correct wrapper, required fields, and structure.
 | Create a MOP command template | `${CLAUDE_PLUGIN_ROOT}/helpers/create-command-template.json` | `POST /mop/createTemplate` |
 | Update a MOP template | `${CLAUDE_PLUGIN_ROOT}/helpers/update-command-template.json` | `POST /mop/updateTemplate/{name}` |
 | Create a JSON form | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json` | `POST /json-forms/forms` |
-| Create an Ops Manager automation + trigger | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-automation.json` | `POST /operations-manager/automations` + `POST /operations-manager/triggers` |
+| Create an Ops Manager automation | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-automation.json` | `POST /operations-manager/automations` |
+| Create a manual trigger (with form) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-manual.json` | `POST /operations-manager/triggers` — `legacyWrapper` MUST be false |
+| Create a scheduled trigger | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-schedule.json` | `POST /operations-manager/triggers` |
+| Import a project (atomic) | `${CLAUDE_PLUGIN_ROOT}/helpers/import-project.json` | `POST /automation-studio/projects/import` |
 | Add assets to a project | `${CLAUDE_PLUGIN_ROOT}/helpers/add-components-to-project.json` | `POST /projects/{id}/components/add` |
 | Update project membership | `${CLAUDE_PLUGIN_ROOT}/helpers/update-project-members.json` | `PATCH /projects/{id}` |
 
@@ -1899,6 +1913,16 @@ When adding a task to a workflow, read the matching template and fill in the fie
 | Application task (WorkFlowEngine, TemplateBuilder, etc.) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-application.json` | `app`, `name`, `canvasName`, incoming/outgoing from schema |
 | Adapter task (ServiceNow, etc.) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-adapter.json` | `app`/`locationType` from apps.json, add `adapter_id`, add error transition |
 | childJob task | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-childjob.json` | `actor: "job"`, `task: ""`, variables use `{"task","value"}` syntax |
+| evaluation / branching | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-evalresult.json` | `operand_1`, `operator`, `operand_2` — both success AND failure transitions required |
+| newVariable | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-newvariable.json` | `name`, `value` — use for error handlers and status flags |
+| query / extract data | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-query.json` | `query` (dot-path), `obj` ($var ref), `pass_on_null` |
+| transformation (JST) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-transformation.json` | `tr_id`, `variableMap`, `options` |
+| getTime | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-gettime.json` | `timezone`, `format` |
+| itential_cli (config push via IAG) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-itential-cli.json` | `_hosts` (device array), `command` (CLI command array), app: `AGManager` |
+| RunCommandTemplate (MOP pre/post check) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-run-command-template.json` | `template`, `variables`, `devices` |
+| viewTemplateResults (MOP review) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-view-template-results.json` | `mop_template_results` — manual task, pauses for operator |
+| reattempt (MOP retry) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-reattempt.json` | `job_id`, `attemptID`, `minutes`, `attempts` |
+| runTemplatesDiff (MOP pre vs post) | `${CLAUDE_PLUGIN_ROOT}/helpers/workflow-task-run-templates-diff.json` | `pre`, `post` — manual task, shows diff to operator |
 
 ### Reference workflows — study these patterns
 
@@ -1911,3 +1935,10 @@ These are complete, tested workflows. Read them to understand how tasks connect,
 | childJob with evaluation (parent orchestrator) | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-parent-workflow.json` | childJob → query → evaluation pattern for checking child success/failure |
 | merge → makeData pattern | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-merge-makedata.json` | Building template variables with merge, then string substitution with makeData |
 | Child with makeData/query/merge | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-child-workflow.json` | Data transformation patterns inside a child workflow |
+| Config push to device (standard pattern) | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-push-config-workflow.json` | renderJinjaTemplate → dry run ViewData → itential_cli (dry) → commit ViewData → itential_cli (commit) |
+| Pre/post check with reattempt (standard pattern) | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-command-template-runner.json` | RunCommandTemplate → viewTemplateResults → evaluation → reattempt loop — use as child for pre-check and post-check |
+| Error handling patterns | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-error-handling-workflow.json` | Try-catch, error flags, escalation paths |
+| Form → OM automation trigger wiring | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-form-to-automation.json` | JSON form → automation → manual trigger end-to-end wiring |
+| IAG gateway service call | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-gateway-service-workflow.json` | Calling IAG services from a workflow via GatewayManager |
+| LCM lifecycle (create + delete) | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-lcm-lifecycle.json` | LCM create/delete workflow pattern, instance object output |
+| Notification workflow | `${CLAUDE_PLUGIN_ROOT}/helpers/reference-notification-workflow.json` | Email/notification patterns |

--- a/helpers/add-components-to-project.json
+++ b/helpers/add-components-to-project.json
@@ -2,17 +2,32 @@
   "components": [
     {
       "type": "workflow",
-      "reference": "",
+      "reference": "REPLACE_WORKFLOW_UUID",
       "folder": "/"
     },
     {
       "type": "template",
-      "reference": "",
+      "reference": "REPLACE_TEMPLATE_UUID",
+      "folder": "/"
+    },
+    {
+      "type": "transformation",
+      "reference": "REPLACE_TRANSFORMATION_UUID",
+      "folder": "/"
+    },
+    {
+      "type": "jsonForm",
+      "reference": "REPLACE_FORM_ID",
       "folder": "/"
     },
     {
       "type": "mopCommandTemplate",
-      "reference": "",
+      "reference": "@REPLACE_PROJECT_ID: REPLACE_TEMPLATE_NAME",
+      "folder": "/"
+    },
+    {
+      "type": "mopAnalyticTemplate",
+      "reference": "@REPLACE_PROJECT_ID: REPLACE_ANALYTIC_TEMPLATE_NAME",
       "folder": "/"
     }
   ],

--- a/helpers/create-ops-manager-trigger-manual.json
+++ b/helpers/create-ops-manager-trigger-manual.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Manual trigger — presents a JSON form before starting the automation. POST /operations-manager/triggers. Set formId to the JSON form _id. CRITICAL: legacyWrapper must be false or form fields get wrapped under 'formData' and break job variable mapping.",
   "name": "",
   "type": "manual",
   "enabled": true,

--- a/helpers/create-project.json
+++ b/helpers/create-project.json
@@ -1,4 +1,4 @@
 {
-  "name": "",
-  "description": ""
+  "name": "REPLACE_PROJECT_NAME",
+  "description": "REPLACE_DESCRIPTION"
 }

--- a/helpers/reference-form-to-automation.json
+++ b/helpers/reference-form-to-automation.json
@@ -2,9 +2,9 @@
   "_comment": "Wiring guide: Form → Trigger → Automation → Workflow. This is the most common end-to-end pattern — a JSON form collects input, a manual trigger presents the form, the trigger fires an automation, and the automation runs a workflow.",
   "_wiring": {
     "step1_create_workflow": {
-      "endpoint": "POST /automation-studio/workflows",
+      "endpoint": "POST /automation-studio/automations",
       "helper": "create-workflow.json",
-      "result": "workflowId (from response._id or response.uuid)"
+      "result": "workflowId (from response.created._id), workflowUuid (from response.created.uuid)"
     },
     "step2_create_form": {
       "endpoint": "POST /json-forms/forms",

--- a/helpers/reference-lcm-lifecycle.json
+++ b/helpers/reference-lcm-lifecycle.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Full LCM lifecycle pattern — create and delete workflows that work with an LCM resource model. The create workflow provisions the service, records start time, and builds the instance object (must output to $var.job.instance). The delete workflow deprovisions and cleans up.",
   "create_workflow": {
     "automation": {
       "name": "Service LCM Create",
@@ -12,7 +11,10 @@
         "workflow_start": {
           "name": "workflow_start",
           "groups": [],
-          "nodeLocation": { "x": 200, "y": 600 }
+          "nodeLocation": {
+            "x": 200,
+            "y": 600
+          }
         },
         "a1b2": {
           "name": "transformation",
@@ -27,17 +29,29 @@
           "variables": {
             "incoming": {
               "tr_id": "",
-              "variableMap": { "formData": "$var.job.formData" },
-              "options": { "extractOutput": true, "validateIncoming": true, "revertToDefaultValue": true }
+              "variableMap": {
+                "formData": "$var.job.formData"
+              },
+              "options": {
+                "extractOutput": true,
+                "validateIncoming": true,
+                "revertToDefaultValue": true
+              }
             },
-            "outgoing": { "serviceName": null, "duration": null },
+            "outgoing": {
+              "serviceName": null,
+              "duration": null
+            },
             "error": "",
             "decorators": []
           },
           "groups": [],
           "actor": "Pronghorn",
           "scheduled": false,
-          "nodeLocation": { "x": 500, "y": 600 }
+          "nodeLocation": {
+            "x": 500,
+            "y": 600
+          }
         },
         "c3d4": {
           "name": "getTime",
@@ -50,15 +64,24 @@
           "type": "automatic",
           "displayName": "Time",
           "variables": {
-            "incoming": { "timezone": "", "offsetDuration": "", "format": "" },
-            "outgoing": { "time": null },
+            "incoming": {
+              "timezone": "",
+              "offsetDuration": "",
+              "format": ""
+            },
+            "outgoing": {
+              "time": null
+            },
             "error": "",
             "decorators": []
           },
           "groups": [],
           "actor": "Pronghorn",
           "scheduled": false,
-          "nodeLocation": { "x": 750, "y": 600 }
+          "nodeLocation": {
+            "x": 750,
+            "y": 600
+          }
         },
         "e5f6": {
           "name": "childJob",
@@ -75,26 +98,34 @@
               "task": "",
               "workflow": "Service Provision Workflow Name",
               "variables": {
-                "serviceName": { "task": "a1b2", "value": "serviceName" }
+                "serviceName": {
+                  "task": "a1b2",
+                  "value": "serviceName"
+                }
               },
               "data_array": "",
               "transformation": "",
               "loopType": ""
             },
-            "outgoing": { "job_details": null },
+            "outgoing": {
+              "job_details": null
+            },
             "error": "",
             "decorators": []
           },
           "groups": [],
           "actor": "job",
           "scheduled": false,
-          "nodeLocation": { "x": 1000, "y": 600 }
+          "nodeLocation": {
+            "x": 1000,
+            "y": 600
+          }
         },
         "a7b8": {
           "name": "transformation",
           "canvasName": "transformation",
           "summary": "Build LCM Instance",
-          "description": "Builds the instance object that LCM stores — must output to $var.job.instance",
+          "description": "Builds the instance object that LCM stores \u2014 must output to $var.job.instance",
           "location": "Application",
           "locationType": null,
           "app": "WorkFlowEngine",
@@ -108,43 +139,88 @@
                 "startTime": "$var.c3d4.time",
                 "provisionResult": "$var.e5f6.job_details"
               },
-              "options": { "extractOutput": true, "validateIncoming": true, "revertToDefaultValue": true }
+              "options": {
+                "extractOutput": true,
+                "validateIncoming": true,
+                "revertToDefaultValue": true
+              }
             },
-            "outgoing": { "instance": "$var.job.instance" },
+            "outgoing": {
+              "instance": null
+            },
             "error": "",
             "decorators": []
           },
           "groups": [],
           "actor": "Pronghorn",
           "scheduled": false,
-          "nodeLocation": { "x": 1250, "y": 600 }
+          "nodeLocation": {
+            "x": 1250,
+            "y": 600
+          }
         },
         "workflow_end": {
           "name": "workflow_end",
           "groups": [],
-          "nodeLocation": { "x": 1500, "y": 600 }
+          "nodeLocation": {
+            "x": 1500,
+            "y": 600
+          }
         }
       },
       "transitions": {
-        "workflow_start": { "a1b2": { "type": "standard", "state": "success" } },
-        "a1b2": { "c3d4": { "type": "standard", "state": "success" } },
-        "c3d4": { "e5f6": { "type": "standard", "state": "success" } },
-        "e5f6": { "a7b8": { "type": "standard", "state": "success" } },
-        "a7b8": { "workflow_end": { "type": "standard", "state": "success" } },
+        "workflow_start": {
+          "a1b2": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
+        "a1b2": {
+          "c3d4": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
+        "c3d4": {
+          "e5f6": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
+        "e5f6": {
+          "a7b8": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
+        "a7b8": {
+          "workflow_end": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
         "workflow_end": {}
       },
       "groups": [],
       "inputSchema": {
         "type": "object",
         "properties": {
-          "formData": { "title": "formData", "type": "object" }
+          "formData": {
+            "title": "formData",
+            "type": "object"
+          }
         },
-        "required": ["formData"]
+        "required": [
+          "formData"
+        ]
       },
       "outputSchema": {
         "type": "object",
         "properties": {
-          "instance": { "title": "instance", "type": "object" }
+          "instance": {
+            "title": "instance",
+            "type": "object"
+          }
         }
       }
     }
@@ -161,7 +237,10 @@
         "workflow_start": {
           "name": "workflow_start",
           "groups": [],
-          "nodeLocation": { "x": 200, "y": 600 }
+          "nodeLocation": {
+            "x": 200,
+            "y": 600
+          }
         },
         "a1b2": {
           "name": "childJob",
@@ -182,24 +261,42 @@
               "transformation": "",
               "loopType": ""
             },
-            "outgoing": { "job_details": null },
+            "outgoing": {
+              "job_details": null
+            },
             "error": "",
             "decorators": []
           },
           "groups": [],
           "actor": "job",
           "scheduled": false,
-          "nodeLocation": { "x": 500, "y": 600 }
+          "nodeLocation": {
+            "x": 500,
+            "y": 600
+          }
         },
         "workflow_end": {
           "name": "workflow_end",
           "groups": [],
-          "nodeLocation": { "x": 800, "y": 600 }
+          "nodeLocation": {
+            "x": 800,
+            "y": 600
+          }
         }
       },
       "transitions": {
-        "workflow_start": { "a1b2": { "type": "standard", "state": "success" } },
-        "a1b2": { "workflow_end": { "type": "standard", "state": "success" } },
+        "workflow_start": {
+          "a1b2": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
+        "a1b2": {
+          "workflow_end": {
+            "type": "standard",
+            "state": "success"
+          }
+        },
         "workflow_end": {}
       },
       "groups": [],

--- a/helpers/update-project-members.json
+++ b/helpers/update-project-members.json
@@ -1,5 +1,14 @@
 {
   "members": [
-    { "type": "account", "role": "owner", "reference": "" }
+    {
+      "type": "account",
+      "role": "editor",
+      "reference": "REPLACE_USER_ACCOUNT_ID"
+    },
+    {
+      "type": "group",
+      "role": "editor",
+      "reference": "REPLACE_GROUP_ID"
+    }
   ]
 }

--- a/helpers/workflow-task-evalresult.json
+++ b/helpers/workflow-task-evalresult.json
@@ -1,9 +1,8 @@
 {
-  "_comment": "The expression object uses operand_1/operand_2 with nested task+variable refs, not flat operand1/operand2. Check task-schemas.json for the exact shape.",
   "name": "evaluation",
   "canvasName": "evaluation",
   "summary": "",
-  "description": "Evaluate an expression and branch the workflow based on the result",
+  "description": "Evaluate an expression and branch the workflow. Uses operand_1/operand_2 with nested task+variable refs — not flat operand1/operand2. Must have BOTH success AND failure transitions. Check task-schemas.json for exact shape.",
   "location": "Application",
   "locationType": null,
   "app": "WorkFlowEngine",

--- a/helpers/workflow-task-itential-cli.json
+++ b/helpers/workflow-task-itential-cli.json
@@ -1,0 +1,30 @@
+{
+  "name": "itential_cli",
+  "canvasName": "itential_cli",
+  "summary": "Push Config to Device",
+  "description": "Pushes CLI commands to devices via IAG AGManager. _hosts is an array of device hostnames, command is an array of CLI command strings. Wire two of these back-to-back: first for dry-run preview, second for commit after user approval via ViewData.",
+  "location": "Application",
+  "locationType": null,
+  "app": "AGManager",
+  "type": "automatic",
+  "displayName": "AG Manager",
+  "variables": {
+    "incoming": {
+      "_hosts": "$var.job.deviceArray",
+      "_groups": "",
+      "command": "$var.job.configCommandArray"
+    },
+    "outgoing": {
+      "stdout": "$var.job.cliOutput"
+    },
+    "error": "",
+    "decorators": []
+  },
+  "groups": [],
+  "actor": "Pronghorn",
+  "scheduled": false,
+  "nodeLocation": {
+    "x": 600,
+    "y": 1308
+  }
+}

--- a/helpers/workflow-task-reattempt.json
+++ b/helpers/workflow-task-reattempt.json
@@ -1,0 +1,31 @@
+{
+  "name": "reattempt",
+  "canvasName": "reattempt",
+  "summary": "Retry Check",
+  "description": "Retries a MOP RunCommandTemplate check after a delay. Wire on the failure path of an evaluation that checks mop_template_results. job_id is the current job ID, attemptID identifies the retry context, minutes is the wait before retrying, attempts is the max retry count.",
+  "location": "Application",
+  "locationType": null,
+  "app": "MOP",
+  "type": "automatic",
+  "displayName": "MOP",
+  "variables": {
+    "incoming": {
+      "job_id": "$var.job._id",
+      "attemptID": "preCheck",
+      "minutes": 2,
+      "attempts": 3
+    },
+    "outgoing": {
+      "response": "$var.job.reattemptResponse"
+    },
+    "error": "",
+    "decorators": []
+  },
+  "groups": [],
+  "actor": "Pronghorn",
+  "scheduled": false,
+  "nodeLocation": {
+    "x": 600,
+    "y": 1308
+  }
+}

--- a/helpers/workflow-task-run-command-template.json
+++ b/helpers/workflow-task-run-command-template.json
@@ -1,0 +1,30 @@
+{
+  "name": "RunCommandTemplate",
+  "canvasName": "RunCommandTemplate",
+  "summary": "Run Pre/Post Check",
+  "description": "Runs a MOP command template against devices and returns pass/fail results per rule. template is the MOP template name, variables is an object of template variable values, devices is an array of device names. mop_template_results feeds into viewTemplateResults and runTemplatesDiff.",
+  "location": "Application",
+  "locationType": null,
+  "app": "MOP",
+  "type": "automatic",
+  "displayName": "MOP",
+  "variables": {
+    "incoming": {
+      "template": "$var.job.templateName",
+      "variables": "$var.job.templateVariables",
+      "devices": "$var.job.devices"
+    },
+    "outgoing": {
+      "mop_template_results": "$var.job.mopResults"
+    },
+    "error": "",
+    "decorators": []
+  },
+  "groups": [],
+  "actor": "Pronghorn",
+  "scheduled": false,
+  "nodeLocation": {
+    "x": 600,
+    "y": 1308
+  }
+}

--- a/helpers/workflow-task-run-templates-diff.json
+++ b/helpers/workflow-task-run-templates-diff.json
@@ -1,0 +1,27 @@
+{
+  "name": "runTemplatesDiff",
+  "canvasName": "runTemplatesDiff",
+  "summary": "Compare Pre vs Post Check",
+  "description": "Manual task — displays a side-by-side diff of pre-check and post-check MOP results to the operator. pre and post are both mop_template_results objects from RunCommandTemplate. Place after the post-check, wire pre from the pre-check childJob output and post from the post-check childJob output.",
+  "location": "Application",
+  "locationType": null,
+  "app": "MOP",
+  "type": "manual",
+  "displayName": "MOP",
+  "variables": {
+    "incoming": {
+      "pre": "$var.job.preCheckResults",
+      "post": "$var.job.postCheckResults"
+    },
+    "outgoing": {},
+    "error": "",
+    "decorators": []
+  },
+  "groups": [],
+  "actor": "Pronghorn",
+  "scheduled": false,
+  "nodeLocation": {
+    "x": 600,
+    "y": 1308
+  }
+}

--- a/helpers/workflow-task-view-template-results.json
+++ b/helpers/workflow-task-view-template-results.json
@@ -1,0 +1,26 @@
+{
+  "name": "viewTemplateResults",
+  "canvasName": "viewTemplateResults",
+  "summary": "Review Check Results",
+  "description": "Manual task — pauses the workflow and displays MOP command template results to the operator in the UI. No outgoing variables. Always follows RunCommandTemplate. Operator clicks through to continue.",
+  "location": "Application",
+  "locationType": null,
+  "app": "MOP",
+  "type": "manual",
+  "displayName": "MOP",
+  "variables": {
+    "incoming": {
+      "mop_template_results": "$var.job.mopResults"
+    },
+    "outgoing": {},
+    "error": "",
+    "decorators": []
+  },
+  "groups": [],
+  "actor": "Pronghorn",
+  "scheduled": false,
+  "nodeLocation": {
+    "x": 600,
+    "y": 1308
+  }
+}


### PR DESCRIPTION
## Summary

- **Config push pattern** — documents `itential_cli` via AGManager as the standard for device config push; clarifies MOP is read-only validation only. Adds the pre-check → push → post-check → diff orchestrator pattern.
- **5 new task helpers** — `itential_cli`, `RunCommandTemplate`, `viewTemplateResults`, `reattempt`, `runTemplatesDiff` — pulled from the Port/VLAN Configuration - JUNOS project as the reference implementation
- **Skill helper table** — all previously unreferenced helpers (task templates, reference workflows, scaffolds) are now referenced so the AI can find and use them
- **Helper fixes** — `add-components-to-project.json` now covers all 6 asset types with correct reference formats; `reference-lcm-lifecycle.json` fixes incorrect `instance` outgoing wiring; `reference-form-to-automation.json` fixes wrong endpoint and response field
- **Project helpers** — `create-project.json` and `update-project-members.json` updated with proper placeholder values and examples

## Test plan

- [ ] Verify `itential_cli` task helper matches the field names used in existing Port/VLAN JUNOS workflows
- [ ] Confirm all new helper file paths resolve correctly from `${CLAUDE_PLUGIN_ROOT}/helpers/`
- [ ] Run a config push delivery end-to-end using the new helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)