### PR TITLE
docs(builder-agent): document REST-bound and cascading JSON Form dropdowns

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -796,8 +796,10 @@ PATCH /automation-studio/projects/{projectId}
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/json-forms/forms` | List all JSON forms |
+| GET | `/json-forms/forms/{id}` | Fetch a single form |
 | POST | `/json-forms/forms` | Create a JSON form |
 | PUT | `/json-forms/forms/{id}` | Update a JSON form (full replacement) |
+| DELETE | `/json-forms/forms` | Bulk delete — body `{"ids":["...","..."]}`. There is no per-id DELETE endpoint. |
 
 ### Create a JSON Form
 
@@ -809,7 +811,24 @@ Use the helper template: `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json`
 
 **Update format:** `PUT /json-forms/forms/{id}` — body MUST be wrapped in `{"options": {...}}` and include ALL fields (`created`, `createdBy`, `lastUpdated`, `lastUpdatedBy`, `name`, `description`, `struct`, `schema`, `uiSchema`, `validationSchema`, `bindingSchema`, `version`). This is a full replacement — omitting any field will clear it.
 
-**Dropdown fields** use `enum`/`enumNames` arrays in both `struct.items` and `schema.properties` — these must stay in sync.
+**Dropdown fields (static enum)** use `enum`/`enumNames` arrays in both `struct.items` and `schema.properties` — these must stay in sync.
+
+**REST-bound dropdowns** — when options should reflect live platform state instead of a hardcoded list, the dropdown's options come from a GET against an IAP endpoint. Use the helper template: `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form-rest-bound.json`.
+
+Three things must line up:
+
+1. **`struct.type` MUST be `"array"`** (not `"object"`). The static-enum scaffold uses `"array"` too — keep it.
+2. **`bindingSchema.properties.<customKey>` must mirror every REST-bound field.** Studio reverse-engineers `bindingSchema` from `struct` in the GUI, but the server does not — leaving `bindingSchema: {}` produces dropdowns that render but never fetch.
+3. **Endpoint discovery:** `GET /automation-studio/json-forms/method-options` returns the canonical list of bindable endpoints — the same list Studio shows in its dropdown picker.
+
+**Cascading dropdowns** (one dropdown's URL path parameter fed by another field's value):
+
+- The dependent dropdown's `href` stays as a TEMPLATE: `/v1/inventories/:inventoryIdentifier/nodes`. **Path params use `:name` colon syntax, NOT `{name}` curly braces.**
+- A `variables` array maps each placeholder to a JSON pointer into form data: `[{ "name": "inventoryIdentifier", "reference": "/site" }]` substitutes `:inventoryIdentifier` with whatever value the field whose `customKey` is `site` currently holds.
+- The same `variables` array must appear in BOTH `struct.items[i].variables` AND `bindingSchema.properties.<dependentKey>.binding:hyperSchema.links[0].variables`.
+- Both the source and the dependent field need `ui:widget: "DependencyWidget"` in `uiSchema` — without it the runtime will not re-fetch when the source changes.
+
+**`labelKeyPointer` is unused.** Both label and value come from `sourceKeyPointer`.
 
 ---
 
@@ -1939,7 +1958,8 @@ Read these first. They have the correct wrapper, required fields, and structure.
 | Create a TextFSM template | `${CLAUDE_PLUGIN_ROOT}/helpers/create-template-textfsm.json` | `POST /automation-studio/templates` |
 | Create a MOP command template | `${CLAUDE_PLUGIN_ROOT}/helpers/create-command-template.json` | `POST /mop/createTemplate` |
 | Update a MOP template | `${CLAUDE_PLUGIN_ROOT}/helpers/update-command-template.json` | `POST /mop/updateTemplate/{name}` |
-| Create a JSON form | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json` | `POST /json-forms/forms` |
+| Create a JSON form (static dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json` | `POST /json-forms/forms` |
+| Create a JSON form (REST-bound or cascading dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form-rest-bound.json` | `POST /json-forms/forms` |
 | Create an Ops Manager automation | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-automation.json` | `POST /operations-manager/automations` |
 | Create a manual trigger (with form) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-manual.json` | `POST /operations-manager/triggers` — `legacyWrapper` MUST be false |
 | Create a scheduled trigger | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-schedule.json` | `POST /operations-manager/triggers` |

--- a/helpers/create-json-form-rest-bound.json
+++ b/helpers/create-json-form-rest-bound.json
@@ -1,0 +1,162 @@
+{
+  "_comment_overview": "JSON Form scaffold for POST /json-forms/forms with REST-BOUND dropdowns whose options are pulled live from an IAP endpoint, including a cascading dependency where one dropdown's URL path parameter is fed by another field's selection. For static enum dropdowns use create-json-form.json instead.",
+
+  "_comment_when_to_use": "Use this template when a dropdown's options should reflect live platform state (devices, inventories, projects, templates, etc.) rather than a hardcoded list. The example below builds a Site/Device cascade against Inventory Manager: dropdown 1 lists inventories, dropdown 2 lists nodes from the selected inventory.",
+
+  "name": "",
+  "description": "",
+
+  "_comment_struct_top": "struct.type MUST be 'array'. Every REST-bound dropdown lives in struct.items[] AND must have a mirror entry in bindingSchema.properties.<customKey> below — Studio reverse-engineers bindingSchema from struct in the GUI but the server does not, so an API-created form needs both populated.",
+
+  "struct": {
+    "type": "array",
+    "items": [
+      {
+        "_comment": "REST-bound dropdown (no cascade). Options come from GET base+href; the response is walked via sourcePointer to an array, and each item's sourceKeyPointer field becomes BOTH the value and the label (labelKeyPointer is unused). Keep enum/enumNames as empty arrays.",
+        "nodeId": "unique-uuid-per-field-1",
+        "type": "string",
+        "title": "Site",
+        "description": "Inventory from Inventory Manager",
+        "placeholder": "Select a site",
+        "required": false,
+        "enum": [],
+        "enumNames": [],
+        "uniqueItems": false,
+        "binding": true,
+        "rel": "collection",
+        "targetPointer": "/enum",
+        "method": "GET",
+        "base": "/inventory_manager",
+        "href": "/v1/inventories",
+        "sourcePointer": "/result/data",
+        "sourceKeyPointer": "/name",
+        "customKey": "site"
+      },
+      {
+        "_comment_cascade": "CASCADING dropdown — depends on the 'site' field above. The href stays as a TEMPLATE with :paramName placeholders (colon syntax, NOT curly braces). The variables array maps each placeholder to a JSON pointer into form data: reference '/site' fills :inventoryIdentifier with whatever value the 'site' field currently holds. originalHref preserves the unresolved template; href is a copy used at runtime. The same variables array MUST also appear inside bindingSchema.properties.device.binding:hyperSchema.links[0].variables below.",
+        "nodeId": "unique-uuid-per-field-2",
+        "type": "string",
+        "title": "Device",
+        "description": "Device (node) from the selected site's inventory",
+        "placeholder": "Select a device",
+        "required": false,
+        "enum": [],
+        "enumNames": [],
+        "uniqueItems": false,
+        "binding": true,
+        "rel": "collection",
+        "targetPointer": "/enum",
+        "method": "GET",
+        "base": "/inventory_manager",
+        "originalHref": "/v1/inventories/:inventoryIdentifier/nodes",
+        "href": "/v1/inventories/:inventoryIdentifier/nodes",
+        "sourcePointer": "/result/data",
+        "sourceKeyPointer": "/name",
+        "variables": [
+          { "name": "inventoryIdentifier", "reference": "/site" }
+        ],
+        "customKey": "device"
+      }
+    ]
+  },
+
+  "_comment_schema": "schema is the data contract — property keys must match customKey values from struct. For REST-bound fields the enum/enumNames stay empty here too.",
+  "schema": {
+    "title": "Site and Device Selector",
+    "description": "Pick a site, then a device from that site",
+    "type": "object",
+    "required": [],
+    "properties": {
+      "site": {
+        "type": "string",
+        "title": "Site",
+        "_id": "/properties/site",
+        "description": "Inventory from Inventory Manager",
+        "enum": [],
+        "enumNames": []
+      },
+      "device": {
+        "type": "string",
+        "title": "Device",
+        "_id": "/properties/device",
+        "description": "Device (node) from the selected site's inventory",
+        "enum": [],
+        "enumNames": []
+      }
+    }
+  },
+
+  "_comment_uiSchema": "Cascading dropdowns require ui:widget 'DependencyWidget' on BOTH the source field and the dependent field. Without it the runtime will not re-fetch the dependent dropdown when the source changes.",
+  "uiSchema": {
+    "site": {
+      "ui:placeholder": "Select a site",
+      "ui:widget": "DependencyWidget"
+    },
+    "device": {
+      "ui:placeholder": "Select a device",
+      "ui:widget": "DependencyWidget"
+    },
+    "ui:order": ["site", "device", "*"]
+  },
+
+  "_comment_bindingSchema": "bindingSchema.properties.<customKey> must mirror every REST-bound field in struct. Keys use 'binding:'-prefixed names. binding:hyperSchema.links[0] holds the actual href + variables; binding:source holds the response-walking pointers. body:variables (note the 'body:' prefix) appears on dependent fields and is normally an empty array.",
+  "bindingSchema": {
+    "properties": {
+      "site": {
+        "binding:method": "GET",
+        "binding:link": { "$ref": "/links", "rel": "collection" },
+        "binding:target": { "propertyPointer": "/enum" },
+        "binding:hyperSchema": {
+          "type": "object",
+          "base": "/inventory_manager",
+          "links": [
+            {
+              "rel": "collection",
+              "href": "/v1/inventories",
+              "targetMediaType": "application/json",
+              "targetSchema": { "$ref": "#" },
+              "variables": []
+            }
+          ]
+        },
+        "binding:source": { "propertyPointer": "/result/data", "keyPointer": "/name" }
+      },
+      "device": {
+        "binding:method": "GET",
+        "binding:link": { "$ref": "/links", "rel": "collection" },
+        "body:variables": [],
+        "binding:target": { "propertyPointer": "/enum" },
+        "binding:hyperSchema": {
+          "type": "object",
+          "base": "/inventory_manager",
+          "links": [
+            {
+              "rel": "collection",
+              "href": "/v1/inventories/:inventoryIdentifier/nodes",
+              "targetMediaType": "application/json",
+              "targetSchema": { "$ref": "#" },
+              "variables": [
+                { "name": "inventoryIdentifier", "reference": "/site" }
+              ]
+            }
+          ]
+        },
+        "binding:source": { "propertyPointer": "/result/data", "keyPointer": "/name" }
+      }
+    }
+  },
+
+  "validationSchema": {},
+  "tags": [],
+  "version": "2020.1",
+
+  "_comment_gotchas": [
+    "struct.type MUST be 'array' — 'object' silently produces a form whose dropdowns never render correctly.",
+    "Path parameters in href use :name colon syntax, NOT {name} curly braces.",
+    "labelKeyPointer is ignored; both label and value come from sourceKeyPointer.",
+    "Cascading needs three things together: (1) variables[] in struct.items, (2) the same variables[] inside bindingSchema...links[0], (3) ui:widget 'DependencyWidget' on both fields.",
+    "To discover what endpoints are bindable, GET /automation-studio/json-forms/method-options — the same list Studio shows in its dropdown picker.",
+    "Bulk delete: DELETE /json-forms/forms with body {\"ids\":[\"...\"]}. There is no DELETE /json-forms/forms/{id}.",
+    "To UPDATE: PUT /json-forms/forms/{id} with body wrapped in {\"options\": {...}} including ALL fields — full replacement."
+  ]
+}

--- a/helpers/create-json-form.json
+++ b/helpers/create-json-form.json
@@ -108,6 +108,7 @@
     "comment": {"ui:placeholder": "Enter comment"}
   },
 
+  "_comment_bindingSchema": "Empty for static-enum forms. For REST-bound or cascading dropdowns use create-json-form-rest-bound.json — bindingSchema must be populated with a binding entry per field.",
   "bindingSchema": {},
   "validationSchema": {},
   "tags": [],


### PR DESCRIPTION
> Replaces #35 — same commit content; only the branch name changed (`claude/...` → `docs/...`) to satisfy the branch-naming CI check.

## Summary

- Adds a new helper template `helpers/create-json-form-rest-bound.json` for JSON Forms whose dropdowns are populated live from IAP endpoints, including the cascading pattern (one dropdown's URL path parameter fed by another field).
- Documents three previously-undocumented details in `builder-agent/SKILL.md`: bulk `DELETE /json-forms/forms`, the `struct` ↔ `bindingSchema` mirroring requirement, and the `variables[]` + `DependencyWidget` mechanism that wires cascading dropdowns.

## Background

While building a Site/Device cascade against Inventory Manager I produced a form whose dropdowns rendered but never fetched. Working from the existing `create-json-form.json` helper, I had assumed `bindingSchema: {}` was always correct and used `{customKey}` curly-brace interpolation in `href`. Both wrong. The user hand-built a working form to demonstrate the actual pattern; this PR captures what was learned so the next agent doesn't repeat the mistakes.

## Changes

**New file: `helpers/create-json-form-rest-bound.json`**
- Annotated scaffold in the same `_comment_*` style as the other helpers
- Worked example: Site (inventory list) → Device (nodes from selected inventory) cascade against Inventory Manager
- Inline gotchas list at the bottom

**Edits: `.claude/skills/builder-agent/SKILL.md`**
- Endpoint table: add `GET /json-forms/forms/{id}` and `DELETE /json-forms/forms` (bulk; body `{"ids":[...]}` — there is no per-id DELETE; per-id 404s)
- New "REST-bound dropdowns" subsection: covers `struct.type: "array"` requirement, the `struct` ↔ `bindingSchema` mirroring requirement, `:name` colon syntax for path params (not `{name}`), the `variables[]` cascade mechanism with `reference` JSON pointers into form data, the `DependencyWidget` `ui:widget` requirement on both source and dependent fields, and `GET /automation-studio/json-forms/method-options` for bindable-endpoint discovery
- Templates table at the bottom: split the JSON Form row into static and REST-bound entries

**Edit: `helpers/create-json-form.json`**
- One-line `_comment_bindingSchema` redirecting readers to the new helper when `bindingSchema` must not be empty

## Test plan

- [ ] `jq type` passes on both helpers (verified locally)
- [ ] POST the new helper's body to `/json-forms/forms` against a live platform → form appears in Studio with two dropdowns
- [ ] Selecting a site repopulates the device dropdown via the cascade (`:inventoryIdentifier` filled from `/site` reference)
- [ ] Bulk DELETE removes both forms
- [ ] Reviewer reads the new SKILL.md subsection and verifies the gotchas match observed Studio behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)