### PR TITLE
docs(discovery): treat RBAC-filtered absence as visibility, not non-existence

### DIFF
--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -131,6 +131,12 @@ GET /lifecycle-manager/model
 GET /automation-studio/projects?limit=500
 ```
 
+> **Visibility caveat:** All list endpoints are RBAC-filtered by the calling client. A platform survey run with a non-admin client will produce an *undercount* — assets gated by ACLs the client isn't on will be silently omitted. Before treating the survey as complete:
+>
+> 1. Confirm the calling client's roles via `GET /iam/clients/{client_id}` and surface them in Step 6's summary.
+> 2. If the client is not an admin, tell the engineer the catalog is *"as visible to client `{client_id}`"* and recommend re-running with an admin-scoped client for a full inventory.
+> 3. Never silently group or omit assets based on a hunch they "must exist somewhere" — only document what the API returns, with the visibility caveat attached.
+
 ### Classification Signatures
 
 | Asset Type | Identifying Fields |
@@ -399,6 +405,7 @@ Flag anything that couldn't be moved (already in a project, API error) for manua
 
 ## Gotchas
 
+- **API survey is RBAC-filtered.** List endpoints in Mode B return only what the calling client can see. A non-admin client will silently undercount the platform. Always run the calling-client check (Step 1, Mode B caveat), report the client and its roles in the Step 6 summary, and label the catalog as *"as visible to client `{client_id}`"* unless the client has admin scope.
 - **NEVER produce JSON files as output.** Only markdown reports.
 - **childJob `workflow` is the primary relationship link.** Don't trace `$var` references across workflows.
 - **Naming prefix is a heuristic, not a rule.** Prioritize childJob graph over naming when they conflict.

--- a/.claude/skills/explore/SKILL.md
+++ b/.claude/skills/explore/SKILL.md
@@ -111,6 +111,8 @@ Show:
 - Devices: count and OS types (if available)
 - Existing workflows: count
 
+> **Visibility note:** All list/get responses above are filtered by the calling client's RBAC. Counts and names reflect *what this client can see*, not what exists on the platform. If the engineer expects a specific project, workflow, or device that does not appear, treat it as *possibly access-restricted*, not *missing* — see the gotcha below.
+
 ---
 
 ## Step 4: Route to Skills
@@ -136,3 +138,4 @@ Point to the right skill for what the engineer wants to do:
 - OpenAPI spec is ~1.5MB — search locally with `jq`, never load into context
 - `tasks/list` `app` field has WRONG casing for adapters — use `apps/list` for correct names
 - Devices endpoint is POST not GET — body required
+- **API responses are RBAC-filtered — absence in a list does NOT mean the resource doesn't exist.** A project, workflow, or device may be present on the platform but invisible to the calling client because the client isn't on its ACL. If the engineer names a specific resource you can't find, say *"not visible to this client (`{client_id}`) — possibly access-restricted; ask the owner or an admin to grant access"* rather than *"doesn't exist"*. Confirming non-existence requires a higher-privilege client or direct DB inspection — never grant access to yourself, ask the engineer how to proceed.

--- a/.claude/skills/project-to-spec/SKILL.md
+++ b/.claude/skills/project-to-spec/SKILL.md
@@ -46,6 +46,19 @@ Response: `{message, data: {_id, name, components: [...], members: [...]}}`
 
 Save the project ID and component list.
 
+### If the project is not returned
+
+Project list/get responses are RBAC-filtered. A 404 or empty `data` array does NOT prove the project doesn't exist — it may be invisible to the calling client.
+
+Before declaring the project missing, do all of:
+
+1. **Identify the calling client** — `GET /iam/clients/{client_id}` (the `client_id` from `.auth.json` or the env file). Confirm whether the client has admin/all-access roles.
+2. **Try a broader query** — `GET /automation-studio/projects?limit=500` and inspect the result for partial-name matches; the `contains` filter is case-sensitive in some Platform versions.
+3. **Surface visibility, not absence** — report: *"No project named `{name}` is visible to this client (`{client_id}`). It may not exist, or it may be access-restricted. To confirm, ask the project owner or an admin to grant `{client_id}` read access via the Automation Studio UI."*
+4. **Do not auto-grant access.** Adding the calling client to a project ACL is a privileged write to a shared resource — always ask the engineer to handle it via the UI or via a separately authorized admin client. If the engineer authorizes a DB-level read-only confirmation (e.g. local dev Mongo), that is acceptable, but the granting itself stays a human action.
+
+Stop and wait for engineer direction before proceeding to Step 2.
+
 ---
 
 ## Step 2: Pull All Components
@@ -236,3 +249,4 @@ Show both documents and walk through:
 - Template `data` field is a JSON string, not an object — parse it before analyzing
 - childJob `workflow` field shows the child workflow name (with prefix) — this is the dependency graph
 - Task descriptions and summaries are the best source of intent — use them heavily
+- **Project not returned ≠ project doesn't exist.** RBAC filters list/get responses by client ACL. A named project the engineer expects but the API doesn't return is more likely access-restricted than missing. Follow the "If the project is not returned" path in Step 1 — never silently switch to a different project, never declare absence without surfacing the visibility caveat, and never grant the calling client access on its own initiative.


### PR DESCRIPTION
## Summary

Three discovery-oriented skills (`explore`, `project-to-spec`, `documentation`) currently encourage Claude to declare a resource missing when an Itential Platform API list/get response comes back empty. But those endpoints are RBAC-filtered: a project, workflow, or device may exist on the platform yet be invisible to the calling client because it isn't on the resource's ACL. This PR teaches the three skills to surface *visibility*, not *absence*, when the API doesn't return an expected resource.

- **`explore`** — adds a "visibility note" under Step 3 (Present Summary) and a Gotcha entry making clear that absence in a list != non-existence, with explicit guidance not to self-grant access.
- **`project-to-spec`** — adds an "If the project is not returned" subsection to Step 1 with four ordered steps (identify the calling client, retry with a broader query, report visibility rather than absence, never auto-grant access). Mirroring Gotcha entry.
- **`documentation`** — adds a visibility caveat under Mode B (Platform API) flagging that non-admin clients silently undercount the platform, and a Gotcha entry. Both push the survey to be labelled *"as visible to client `{client_id}`"* unless the client has admin scope.

3 files changed, +24 lines, no deletions. Conventional-commit style and tone follow #27 (docs(builder-agent): ask engineer before patching project membership).

## Motivation

Real incident: a user asked Claude whether their `IPAM Automation` project existed on the platform. `GET /automation-studio/projects?equals={"name":"IPAM"}` returned an empty array, so Claude said "no project named IPAM is on the platform." The project was actually present (`_id 69271c373e8461ffaa5a74a1`, owned by another user) — the calling OAuth client just wasn't on its ACL. The fix was for the project owner to grant access via the UI. The skills as written today push toward the wrong conclusion in this scenario; this PR corrects that.

## Test plan

- [ ] Read each modified SKILL.md and confirm the new wording flows with the surrounding sections.
- [ ] In a session with `/explore` against a Platform where the OAuth client lacks access to a known project, confirm the assistant reports the project as *not visible to this client* rather than declaring it absent.
- [ ] In a `/project-to-spec` session with a project name the calling client cannot see, confirm the assistant follows the new Step 1 path (identifies caller, broadens query, surfaces visibility) instead of immediately moving on.
- [ ] In a `/documentation` Mode B session with a non-admin client, confirm the resulting catalog is labelled *"as visible to client `{client_id}`"* and the Step 6 summary names the client and its roles.
- [ ] No behavior change expected when the calling client is admin-scoped or the resource is genuinely absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)