### PR TITLE
docs(contributing): document commit and branch CI rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ This project uses a fork and pull request model for contributions:
    git checkout -b feature/your-feature-name
    ```
 
-3. **Make your changes** in logical, atomic commits
+3. **Make your changes** in logical, atomic commits — every commit message must follow the [Commit Message Format](#commit-message-format) below; CI will reject the PR otherwise
 4. **Test your changes** thoroughly
 5. **Push to your fork:**
    ```bash
@@ -116,17 +116,68 @@ This project uses a fork and pull request model for contributions:
 
 ### Branch Naming Conventions
 
-Use descriptive branch names with prefixes:
-- `feature/` - New features
-- `fix/` - Bug fixes
-- `chore/` - Maintenance tasks
-- `docs/` - Documentation updates
+Branch names are validated by CI against this regex:
+
+```
+^(feature|fix|refactor|docs|chore)/[a-z][a-z0-9-]*$
+```
+
+Format: `<type>/<description>` where:
+
+| Field | Rule |
+|---|---|
+| Type | One of `feature`, `fix`, `refactor`, `docs`, `chore` |
+| Description | Lowercase letters, numbers, and hyphens only; must start with a letter |
+
+Type meanings:
+- `feature/` — new features
+- `fix/` — bug fixes
+- `refactor/` — code restructuring without changing behavior
+- `chore/` — maintenance tasks (dependencies, tooling, build)
+- `docs/` — documentation updates
 
 Examples:
 - `feature/add-authentication-support`
 - `fix/handle-connection-timeout`
+- `refactor/extract-token-helper`
 - `chore/update-dependencies`
 - `docs/improve-api-examples`
+
+### Commit Message Format
+
+Every commit on a PR is validated by CI against the [Conventional Commits](https://www.conventionalcommits.org/) regex:
+
+```
+^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+\))?: .{1,72}
+```
+
+Format: `<type>[(scope)]: <description>` where:
+
+| Field | Rule |
+|---|---|
+| Type | One of `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf` |
+| Scope | *(Optional)* parenthesized, e.g. `(builder-agent)` |
+| Description | 1–72 characters |
+
+> **Note** — the commit type list is **different from the branch type list**. Branches use `feature/` (full word); commits use `feat:` (Conventional Commits short form). Branches don't have `style`, `test`, or `perf`.
+
+Type meanings (commit-side):
+- `feat` — new feature
+- `fix` — bug fix
+- `docs` — documentation only
+- `style` — formatting, whitespace, missing semicolons (no code logic change)
+- `refactor` — code restructuring without behavior change
+- `test` — adding or fixing tests
+- `chore` — build process, tooling, dependencies
+- `perf` — performance improvements
+
+**Merge commits are not allowed** on PR branches — the CI rejects them. Use squash or rebase to integrate updates from `main`.
+
+Examples:
+- `feat(auth): add JWT token validation`
+- `fix: handle empty response from upstream`
+- `docs(contributing): document commit and branch CI rules`
+- `chore: bump dependency versions`
 
 ## Pull Request Guidelines
 


### PR DESCRIPTION
## Summary
Surface the regexes that `.github/workflows/pr-compliance.yml` enforces on every PR — Conventional Commits for commit messages and the branch-name pattern — so contributors don't get blocked by CI before they know the rules exist.

Hit during #40: my commit was rejected for `Default to vertical canvas orientation` (no `docs:` prefix). The CI error pointed at CONTRIBUTING.md as the source of truth, but CONTRIBUTING.md said nothing about commit format.

## Changes
- **Branch Naming Conventions** rewritten with the literal CI regex `^(feature|fix|refactor|docs|chore)/[a-z][a-z0-9-]*$`, a field-by-field rule table, and per-type meanings. Adds `refactor/` to the documented list (CI accepts it; doc had omitted it).
- **New "Commit Message Format" subsection**: the literal `^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+\))?: .{1,72}` regex, allowed types, optional scope, 72-char description limit, the no-merge-commits rule, and examples.
- Calls out the type-list mismatch — branches use `feature/` (full word), commits use `feat:` (Conventional Commits short form). Easy footgun.
- Cross-links from step 3 of "Fork and Pull Model" so readers see the rule before they start writing commits.

## Testing
- [x] Branch name `docs/contributing-ci-rules` matches the documented regex
- [x] Commit message `docs(contributing): document commit and branch CI rules` matches the documented regex (54 chars)
- [x] CI checks (`Branch Naming`, `Commit Messages`) are expected to pass — this PR self-validates the documented rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)