### PR TITLE
feat(app-json_forms): create dedicated skill for JSON Forms

### DIFF
--- a/.claude/skills/app-json_forms/SKILL.md
+++ b/.claude/skills/app-json_forms/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: app-json_forms
+description: Build IAP JSON Forms — static-enum dropdowns, REST-bound dropdowns (live data pulled from IAP endpoints), and cascading dropdowns (aka field dependency — one field's value drives another's URL path param). Use when creating, updating, or wiring forms consumed by manual triggers, manual tasks (ShowJsonForm), or any UI surface that needs a structured input panel.
+argument-hint: "[form name or operation]"
+---
+
+# JSON Forms (app-json_forms)
+
+JSON Forms are reusable form definitions stored in the `json-forms` application. They drive structured input panels across IAP — manual triggers in Operations Manager, the `JsonForms/ShowJsonForm` manual task, and any workflow surface that prompts a user for typed input.
+
+A form is a single document with four cooperating schemas — `struct` (UI rendering), `schema` (data contract / validation), `uiSchema` (per-field widget hints), and `bindingSchema` (live-data binding for REST dropdowns). Get the relationships wrong and the form will render but break silently at runtime.
+
+## Concepts
+
+- **`struct`** — the UI definition. `struct.type` is always `"array"`; `struct.items[]` is the list of fields. `customKey` on each field becomes the property key in `schema` and the variable key when the form's data is consumed.
+- **`schema`** — the data contract. `schema.properties.<customKey>` must exist for every field in `struct.items[]` (and stay in sync with the field's type, enum values, etc.). `schema.required` lists mandatory `customKey`s.
+- **`uiSchema`** — per-`customKey` widget hints: placeholder text, `ui:widget` overrides, disabled flags. Required for cascading dropdowns (see below).
+- **`bindingSchema`** — empty `{}` for static-enum forms. Required (and non-trivial) for REST-bound dropdowns: every REST-bound field needs a mirroring `bindingSchema.properties.<customKey>` entry. Studio fills this in invisibly through the GUI; the server does not.
+- **Static vs. REST-bound dropdowns** — static dropdowns hardcode the list via `enum`/`enumNames`. REST-bound dropdowns pull options live from an IAP endpoint at form-render time.
+- **Cascading dropdowns** (aka **field dependency** in the Studio UI) — a REST-bound dropdown whose URL path parameter is filled from another field's current value. The dependent field re-fetches when the source field changes.
+
+## API Reference
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/json-forms/forms` | List all JSON forms |
+| GET | `/json-forms/forms/{id}` | Fetch a single form |
+| POST | `/json-forms/forms` | Create a JSON form |
+| PUT | `/json-forms/forms/{id}` | Update a JSON form (full replacement — see Update below) |
+| DELETE | `/json-forms/forms` | Bulk delete — body `{"ids":["...","..."]}`. There is no per-id DELETE endpoint; per-id calls 404. |
+| GET | `/automation-studio/json-forms/method-options` | Canonical list of bindable endpoints (same list Studio shows in its dropdown picker) |
+
+## Create a JSON Form
+
+```
+POST /json-forms/forms
+```
+
+Choose the helper that matches your form's dropdown needs:
+
+| Use case | Helper |
+|---|---|
+| Static-enum dropdowns only (hardcoded option lists) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json` |
+| REST-bound or cascading dropdowns (live data from IAP endpoints) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form-rest-bound.json` |
+
+Both helpers are annotated scaffolds — read the `_comment_*` fields inline before customizing.
+
+### Static-enum dropdowns
+
+`enum`/`enumNames` arrays appear in both `struct.items[i]` and `schema.properties.<customKey>` — they must stay in sync.
+
+- `struct.items[i].enum` / `enumNames` are arrays of `{id, label, value}` objects.
+- `schema.properties.<customKey>.enum` / `enumNames` are **flat string arrays** of the same values (not objects).
+
+Leave `bindingSchema: {}` for static-enum forms.
+
+### REST-bound dropdowns
+
+When options should reflect live platform state (devices, inventories, projects, templates) instead of a hardcoded list, the dropdown pulls from a GET against an IAP endpoint at render time. Three things must line up:
+
+1. **`struct.type` MUST be `"array"`** (not `"object"`). The static-enum scaffold uses `"array"` too — keep it.
+2. **`bindingSchema.properties.<customKey>` must mirror every REST-bound field.** Studio reverse-engineers `bindingSchema` from `struct` in the GUI, but the server does not — leaving `bindingSchema: {}` produces dropdowns that render but never fetch.
+3. **Endpoint discovery:** `GET /automation-studio/json-forms/method-options` returns the canonical list of bindable endpoints — the same list Studio shows in its dropdown picker.
+
+Per-field shape in `struct.items[i]`:
+
+```jsonc
+{
+  "type": "string",
+  "title": "Site",
+  "binding": true,
+  "rel": "collection",
+  "targetPointer": "/enum",
+  "method": "GET",
+  "base": "/inventory_manager",
+  "href": "/v1/inventories",
+  "sourcePointer": "/result/data",
+  "sourceKeyPointer": "/name",
+  "customKey": "site"
+}
+```
+
+- `base + href` is the endpoint.
+- `sourcePointer` is a JSON pointer into the response, walked to the array of items.
+- `sourceKeyPointer` is the per-item field that becomes BOTH the value and the label. **`labelKeyPointer` is unused** — both columns come from `sourceKeyPointer`.
+
+### Cascading dropdowns (aka field dependency)
+
+The Studio UI labels this pattern **field dependency**; the form JSON calls it cascading. Same feature, two names. A REST-bound dropdown whose URL path parameter is filled from another field's value (e.g., dropdown 2 lists devices from the inventory selected in dropdown 1):
+
+- The dependent dropdown's `href` stays as a **TEMPLATE** with placeholders: `/v1/inventories/:inventoryIdentifier/nodes`. **Path params use `:name` colon syntax, NOT `{name}` curly braces.**
+- A `variables` array maps each placeholder to a JSON pointer into form data: `[{"name": "inventoryIdentifier", "reference": "/site"}]` substitutes `:inventoryIdentifier` with whatever value the field whose `customKey` is `site` currently holds.
+- The same `variables` array must appear in **both** places:
+  - `struct.items[i].variables`
+  - `bindingSchema.properties.<dependentKey>.binding:hyperSchema.links[0].variables`
+- **Both the source and the dependent field need `ui:widget: "DependencyWidget"`** in `uiSchema` — without it, the runtime will not re-fetch when the source changes.
+
+## Update a JSON Form
+
+```
+PUT /json-forms/forms/{id}
+```
+
+- Body MUST be wrapped in `{"options": {...}}`.
+- Include ALL fields the form already has: `created`, `createdBy`, `lastUpdated`, `lastUpdatedBy`, `name`, `description`, `struct`, `schema`, `uiSchema`, `validationSchema`, `bindingSchema`, `version`.
+- This is a **full replacement** — omitting any field clears it.
+
+## Delete JSON Forms
+
+Bulk-only:
+
+```
+DELETE /json-forms/forms
+Body: {"ids": ["<id1>", "<id2>", ...]}
+```
+
+Per-id calls (`DELETE /json-forms/forms/<id>`) return 404 — the endpoint does not exist.
+
+## Wiring to a Manual Trigger
+
+A JSON Form is consumed by an Operations Manager **manual trigger** that hands the user's form input to a workflow as job variables. See `builder-agent` for the trigger creation details.
+
+**Critical flag — `legacyWrapper: false`:** The default is `true`, which wraps form field values under a `formData` object and breaks the mapping to workflow job variables. Set `legacyWrapper: false` so each form field maps directly to a workflow input variable by name (i.e., field `customKey: "device_name"` → job variable `device_name`).
+
+Required trigger fields: `name`, `type` (`"manual"`), `enabled`, `actionType` (`"automations"`), `actionId`, `formId`, `legacyWrapper`.
+
+Helper for the wired-up trigger: `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-manual.json`.
+
+## Common Gotchas
+
+- **`struct.type` is `"array"`, not `"object"`.** Forms with `"object"` render empty.
+- **`bindingSchema` mirroring is mandatory for REST-bound fields.** Studio hides this in the GUI; an API-created form needs both `struct.items[i]` AND `bindingSchema.properties.<customKey>` populated, or the dropdown renders and never fetches.
+- **`:name` colon syntax in `href`, not `{name}`.** Curly-brace placeholders are silently ignored.
+- **`enum`/`enumNames` flat-vs-object asymmetry.** In `struct.items[i]` they're `{id, label, value}` objects; in `schema.properties.<customKey>` they're flat string arrays.
+- **`DependencyWidget` required on BOTH ends of a cascade.** Easy to remember to set it on the dependent field and forget the source — without the source-side widget the dependent won't re-fetch.
+- **`labelKeyPointer` is a red herring.** Don't bother setting it; both label and value come from `sourceKeyPointer`.
+- **Bulk DELETE has no per-id alternative.** Always send `{"ids":[...]}` to `/json-forms/forms`.
+
+## See Also
+
+- `builder-agent` for workflows that consume form output, manual-trigger wiring, and project-level component management.
+- Helper files in `${CLAUDE_PLUGIN_ROOT}/helpers/`:
+  - `create-json-form.json` — static-enum scaffold
+  - `create-json-form-rest-bound.json` — REST-bound + cascading scaffold (Inventory Manager Site/Device cascade worked example)
+  - `create-ops-manager-trigger-manual.json` — manual trigger that consumes a form

--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -800,23 +800,11 @@ PATCH /automation-studio/projects/{projectId}
 
 ## JSON Forms
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/json-forms/forms` | List all JSON forms |
-| POST | `/json-forms/forms` | Create a JSON form |
-| PUT | `/json-forms/forms/{id}` | Update a JSON form (full replacement) |
+JSON Forms have their own dedicated skill — `app-json_forms`. See that skill for the form structure (`struct` / `schema` / `uiSchema` / `bindingSchema`), the static-enum vs. REST-bound vs. cascading dropdown (aka field dependency) patterns, the full API reference (including the bulk-only DELETE), and the manual-trigger wiring (`legacyWrapper: false`).
 
-### Create a JSON Form
-
-```
-POST /json-forms/forms
-```
-
-Use the helper template: `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json`
-
-**Update format:** `PUT /json-forms/forms/{id}` — body MUST be wrapped in `{"options": {...}}` and include ALL fields (`created`, `createdBy`, `lastUpdated`, `lastUpdatedBy`, `name`, `description`, `struct`, `schema`, `uiSchema`, `validationSchema`, `bindingSchema`, `version`). This is a full replacement — omitting any field will clear it.
-
-**Dropdown fields** use `enum`/`enumNames` arrays in both `struct.items` and `schema.properties` — these must stay in sync.
+Helper templates for forms still live under `${CLAUDE_PLUGIN_ROOT}/helpers/`:
+- `create-json-form.json` — static-enum dropdowns
+- `create-json-form-rest-bound.json` — REST-bound or cascading dropdowns
 
 ---
 
@@ -2041,7 +2029,8 @@ Read these first. They have the correct wrapper, required fields, and structure.
 | Create a TextFSM template | `${CLAUDE_PLUGIN_ROOT}/helpers/create-template-textfsm.json` | `POST /automation-studio/templates` |
 | Create a MOP command template | `${CLAUDE_PLUGIN_ROOT}/helpers/create-command-template.json` | `POST /mop/createTemplate` |
 | Update a MOP template | `${CLAUDE_PLUGIN_ROOT}/helpers/update-command-template.json` | `POST /mop/updateTemplate/{name}` |
-| Create a JSON form | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json` | `POST /json-forms/forms` |
+| Create a JSON form (static dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form.json` | `POST /json-forms/forms` — see `app-json_forms` skill |
+| Create a JSON form (REST-bound or cascading dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-json-form-rest-bound.json` | `POST /json-forms/forms` — see `app-json_forms` skill |
 | Create an Ops Manager automation | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-automation.json` | `POST /operations-manager/automations` |
 | Create a manual trigger (with form) | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-manual.json` | `POST /operations-manager/triggers` — `legacyWrapper` MUST be false |
 | Create a scheduled trigger | `${CLAUDE_PLUGIN_ROOT}/helpers/create-ops-manager-trigger-schedule.json` | `POST /operations-manager/triggers` |

--- a/helpers/create-json-form-rest-bound.json
+++ b/helpers/create-json-form-rest-bound.json
@@ -1,0 +1,162 @@
+{
+  "_comment_overview": "JSON Form scaffold for POST /json-forms/forms with REST-BOUND dropdowns whose options are pulled live from an IAP endpoint, including a cascading dependency (aka field dependency, as the Studio UI labels it) where one dropdown's URL path parameter is fed by another field's selection. For static enum dropdowns use create-json-form.json instead.",
+
+  "_comment_when_to_use": "Use this template when a dropdown's options should reflect live platform state (devices, inventories, projects, templates, etc.) rather than a hardcoded list. The example below builds a Site/Device cascade against Inventory Manager: dropdown 1 lists inventories, dropdown 2 lists nodes from the selected inventory.",
+
+  "name": "",
+  "description": "",
+
+  "_comment_struct_top": "struct.type MUST be 'array'. Every REST-bound dropdown lives in struct.items[] AND must have a mirror entry in bindingSchema.properties.<customKey> below — Studio reverse-engineers bindingSchema from struct in the GUI but the server does not, so an API-created form needs both populated.",
+
+  "struct": {
+    "type": "array",
+    "items": [
+      {
+        "_comment": "REST-bound dropdown (no cascade). Options come from GET base+href; the response is walked via sourcePointer to an array, and each item's sourceKeyPointer field becomes BOTH the value and the label (labelKeyPointer is unused). Keep enum/enumNames as empty arrays.",
+        "nodeId": "unique-uuid-per-field-1",
+        "type": "string",
+        "title": "Site",
+        "description": "Inventory from Inventory Manager",
+        "placeholder": "Select a site",
+        "required": false,
+        "enum": [],
+        "enumNames": [],
+        "uniqueItems": false,
+        "binding": true,
+        "rel": "collection",
+        "targetPointer": "/enum",
+        "method": "GET",
+        "base": "/inventory_manager",
+        "href": "/v1/inventories",
+        "sourcePointer": "/result/data",
+        "sourceKeyPointer": "/name",
+        "customKey": "site"
+      },
+      {
+        "_comment_cascade": "CASCADING dropdown (the Studio UI labels this pattern 'field dependency'). Depends on the 'site' field above. The href stays as a TEMPLATE with :paramName placeholders (colon syntax, NOT curly braces). The variables array maps each placeholder to a JSON pointer into form data: reference '/site' fills :inventoryIdentifier with whatever value the 'site' field currently holds. originalHref preserves the unresolved template; href is a copy used at runtime. The same variables array MUST also appear inside bindingSchema.properties.device.binding:hyperSchema.links[0].variables below.",
+        "nodeId": "unique-uuid-per-field-2",
+        "type": "string",
+        "title": "Device",
+        "description": "Device (node) from the selected site's inventory",
+        "placeholder": "Select a device",
+        "required": false,
+        "enum": [],
+        "enumNames": [],
+        "uniqueItems": false,
+        "binding": true,
+        "rel": "collection",
+        "targetPointer": "/enum",
+        "method": "GET",
+        "base": "/inventory_manager",
+        "originalHref": "/v1/inventories/:inventoryIdentifier/nodes",
+        "href": "/v1/inventories/:inventoryIdentifier/nodes",
+        "sourcePointer": "/result/data",
+        "sourceKeyPointer": "/name",
+        "variables": [
+          { "name": "inventoryIdentifier", "reference": "/site" }
+        ],
+        "customKey": "device"
+      }
+    ]
+  },
+
+  "_comment_schema": "schema is the data contract — property keys must match customKey values from struct. For REST-bound fields the enum/enumNames stay empty here too.",
+  "schema": {
+    "title": "Site and Device Selector",
+    "description": "Pick a site, then a device from that site",
+    "type": "object",
+    "required": [],
+    "properties": {
+      "site": {
+        "type": "string",
+        "title": "Site",
+        "_id": "/properties/site",
+        "description": "Inventory from Inventory Manager",
+        "enum": [],
+        "enumNames": []
+      },
+      "device": {
+        "type": "string",
+        "title": "Device",
+        "_id": "/properties/device",
+        "description": "Device (node) from the selected site's inventory",
+        "enum": [],
+        "enumNames": []
+      }
+    }
+  },
+
+  "_comment_uiSchema": "Cascading dropdowns require ui:widget 'DependencyWidget' on BOTH the source field and the dependent field. Without it the runtime will not re-fetch the dependent dropdown when the source changes.",
+  "uiSchema": {
+    "site": {
+      "ui:placeholder": "Select a site",
+      "ui:widget": "DependencyWidget"
+    },
+    "device": {
+      "ui:placeholder": "Select a device",
+      "ui:widget": "DependencyWidget"
+    },
+    "ui:order": ["site", "device", "*"]
+  },
+
+  "_comment_bindingSchema": "bindingSchema.properties.<customKey> must mirror every REST-bound field in struct. Keys use 'binding:'-prefixed names. binding:hyperSchema.links[0] holds the actual href + variables; binding:source holds the response-walking pointers. body:variables (note the 'body:' prefix) appears on dependent fields and is normally an empty array.",
+  "bindingSchema": {
+    "properties": {
+      "site": {
+        "binding:method": "GET",
+        "binding:link": { "$ref": "/links", "rel": "collection" },
+        "binding:target": { "propertyPointer": "/enum" },
+        "binding:hyperSchema": {
+          "type": "object",
+          "base": "/inventory_manager",
+          "links": [
+            {
+              "rel": "collection",
+              "href": "/v1/inventories",
+              "targetMediaType": "application/json",
+              "targetSchema": { "$ref": "#" },
+              "variables": []
+            }
+          ]
+        },
+        "binding:source": { "propertyPointer": "/result/data", "keyPointer": "/name" }
+      },
+      "device": {
+        "binding:method": "GET",
+        "binding:link": { "$ref": "/links", "rel": "collection" },
+        "body:variables": [],
+        "binding:target": { "propertyPointer": "/enum" },
+        "binding:hyperSchema": {
+          "type": "object",
+          "base": "/inventory_manager",
+          "links": [
+            {
+              "rel": "collection",
+              "href": "/v1/inventories/:inventoryIdentifier/nodes",
+              "targetMediaType": "application/json",
+              "targetSchema": { "$ref": "#" },
+              "variables": [
+                { "name": "inventoryIdentifier", "reference": "/site" }
+              ]
+            }
+          ]
+        },
+        "binding:source": { "propertyPointer": "/result/data", "keyPointer": "/name" }
+      }
+    }
+  },
+
+  "validationSchema": {},
+  "tags": [],
+  "version": "2020.1",
+
+  "_comment_gotchas": [
+    "struct.type MUST be 'array' — 'object' silently produces a form whose dropdowns never render correctly.",
+    "Path parameters in href use :name colon syntax, NOT {name} curly braces.",
+    "labelKeyPointer is ignored; both label and value come from sourceKeyPointer.",
+    "Cascading needs three things together: (1) variables[] in struct.items, (2) the same variables[] inside bindingSchema...links[0], (3) ui:widget 'DependencyWidget' on both fields.",
+    "To discover what endpoints are bindable, GET /automation-studio/json-forms/method-options — the same list Studio shows in its dropdown picker.",
+    "Bulk delete: DELETE /json-forms/forms with body {\"ids\":[\"...\"]}. There is no DELETE /json-forms/forms/{id}.",
+    "To UPDATE: PUT /json-forms/forms/{id} with body wrapped in {\"options\": {...}} including ALL fields — full replacement."
+  ]
+}

--- a/helpers/create-json-form.json
+++ b/helpers/create-json-form.json
@@ -108,6 +108,7 @@
     "comment": {"ui:placeholder": "Enter comment"}
   },
 
+  "_comment_bindingSchema": "Empty for static-enum forms. For REST-bound or cascading dropdowns (aka field dependency in the Studio UI) use create-json-form-rest-bound.json — bindingSchema must be populated with a binding entry per field.",
   "bindingSchema": {},
   "validationSchema": {},
   "tags": [],


### PR DESCRIPTION
## Summary
Re-opens #36 per @keepithuman's review. Instead of expanding `builder-agent` with REST-bound and cascading dropdown content, the JSON Forms application gets its own dedicated skill.

Closes #36.

## Changes

**New skill — `.claude/skills/app-json_forms/SKILL.md`**

Covers the full JSON Forms surface:
- Form structure (`struct` / `schema` / `uiSchema` / `bindingSchema`) and how the four schemas cooperate
- Static-enum dropdowns (`enum`/`enumNames` sync rules across `struct` and `schema`)
- REST-bound dropdowns (`bindingSchema` mirroring requirement, endpoint discovery via `/automation-studio/json-forms/method-options`, per-field shape with `base`/`href`/`sourcePointer`/`sourceKeyPointer`)
- Cascading dropdowns (`:name` colon syntax, `variables[]` mapping with JSON pointers, the both-ends `DependencyWidget` requirement)
- Full API reference, including the bulk-only DELETE (`{"ids":[...]}` — per-id calls 404)
- Update semantics (`{"options": ...}` wrapper, full-replacement requirement)
- Wiring to Operations Manager manual triggers (`legacyWrapper: false`)
- Common gotchas section calling out the silent failure modes (`bindingSchema: {}` rendering but not fetching, `{name}` curly-brace placeholders being ignored, `labelKeyPointer` being a red herring, etc.)

**`helpers/create-json-form-rest-bound.json`** (new) — annotated scaffold in the same `_comment_*` style as the other helpers. Worked example: Site/Device cascade against Inventory Manager.

**`helpers/create-json-form.json`** — one-line `_comment_bindingSchema` redirecting readers to the new helper when `bindingSchema` must not be empty.

**`.claude/skills/builder-agent/SKILL.md`**
- JSON Forms subsection shrinks to a pointer at the new skill, so there's no duplicated source of truth.
- Templates table at the bottom splits the JSON Form row into static-enum and REST-bound entries, both pointing at `app-json_forms` for full details.

## Background

While building a Site/Device cascade against Inventory Manager I produced a form whose dropdowns rendered but never fetched. Working from the existing `create-json-form.json` helper, I had assumed `bindingSchema: {}` was always correct and used `{customKey}` curly-brace interpolation in `href`. Both wrong. @ZackStr hand-built a working form to demonstrate the actual pattern; this PR captures what was learned. PR #36 put the content in `builder-agent`; this PR moves it to a dedicated skill per @keepithuman's review feedback.

## Test plan

- [x] Both helper JSON files parse (`python -m json.tool`)
- [x] New skill frontmatter matches the convention used by `itential-mop`, `itential-lcm`, etc. (yaml block with `name`, `description`, `argument-hint`)
- [x] No duplicated source of truth — `builder-agent` redirects, doesn't repeat
- [x] CI checks (branch `feature/app-json-forms-skill` and commit `feat(app-json_forms): ...`) match the documented regexes
- [ ] Reviewer to POST `helpers/create-json-form-rest-bound.json` to `/json-forms/forms` against a live platform → form appears in Studio with two dropdowns; selecting a site repopulates the device dropdown via the cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)