### PR TITLE
feat: ask engineer for project members when no spec membership is defined

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -790,6 +790,8 @@ PATCH /automation-studio/projects/{projectId}
 
 > **If a username or group cannot be resolved from the lookup table, stop and ask the engineer.** Do not guess reference IDs or skip members.
 
+**Baseline members (when no spec membership is defined):** If there is no Project Membership table in the spec, or when doing a freeform build/import outside the spec lifecycle, **ask the engineer:** *"Which user accounts or groups should have access to this project?"* — do not assume or skip. Once you have the names, resolve them via the lookup table above and PATCH immediately. Without this step the engineer will be locked out of the project in the IAP UI. See [#63](https://github.com/itential/builder-skills/issues/63)
+
 ---
 
 ## JSON Forms


### PR DESCRIPTION
## Summary

When there is no Project Membership table in the spec (freeform builds, prebuilt imports), the agent currently has no guidance and silently skips the membership step — leaving the engineer locked out of the project in the IAP UI after creation.

## Changes

- Added a **Baseline members** note to the "Resolve membership references from spec" section in `/builder-agent` SKILL.md
- When no spec membership is defined, the agent now asks the engineer which accounts or groups should have access before patching — rather than assuming a specific account ID or skipping the step entirely

## Testing

- Validated the scenario during an on-prem delivery session: agent created a project, engineer was locked out, root cause was no membership PATCH after creation

## Related Issues

Closes #63