### PR TITLE
fix(builder-agent): add task-output example and P6.4.0 warning for childJob variables

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -496,6 +496,10 @@ The parent passes specific variables to one child workflow run.
 - `{"task": "static", "value": "validate"}` → passes the literal string `"validate"`
 - `{"task": "b2c3", "value": "return_data"}` → passes a previous task's output (preferred for runtime data)
 
+> **WRONG for task output refs in childJob:**
+> `{"task": "b2c3", "variable": "return_data"}` — `"variable"` is for merge/evaluation only.
+> In childJob, ALL refs (job, static, AND task output) use `"value"`. Using `"variable"` causes `undefined.indexOf()` at job start time (P6.4.0+) — the workflow fails before any task runs.
+
 **Extracting single child output:**
 ```json
 {

--- a/helpers/reference-parent-workflow.json
+++ b/helpers/reference-parent-workflow.json
@@ -33,6 +33,10 @@
               "deviceName": {
                 "task": "job",
                 "value": "deviceName"
+              },
+              "configData": {
+                "task": "prevTaskId",
+                "value": "return_data"
               }
             },
             "data_array": "",

--- a/helpers/workflow-task-childjob.json
+++ b/helpers/workflow-task-childjob.json
@@ -16,6 +16,10 @@
         "childInputVar": {
           "task": "job",
           "value": "parentJobVar"
+        },
+        "childInputFromTask": {
+          "task": "prevTaskId",
+          "value": "return_data"
         }
       },
       "data_array": "",


### PR DESCRIPTION
## Summary

Neither helper file showed a task output reference in childJob variables, making it easy to accidentally apply the merge/evaluation \`"variable"\` key instead of the correct \`"value"\` key. P6.4.0 added stricter validation that crashes with \`undefined.indexOf()\` at job start time when \`"variable"\` is used.

## Changes

- \`helpers/workflow-task-childjob.json\` — added \`childInputFromTask\` example entry using \`{"task":"prevTaskId","value":"return_data"}\`
- \`helpers/reference-parent-workflow.json\` — added \`configData\` task-output variable to the childJob in the reference workflow
- \`SKILL.md\` — added explicit WRONG callout directly below the variable passing rules in Guide 4

## Test plan
- [ ] Confirm helper files are valid JSON
- [ ] Verify SKILL.md WRONG callout is immediately visible in Guide 4 Mode A

🤖 Generated with [Claude Code](https://claude.com/claude-code)