### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI agent skills for the Itential Platform — deliver infrastructure automation from spec through build.",
-    "version": "1.1.1"
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "itential/builder-skills"
       },
       "description": "AI agent skills for the Itential Platform — deliver infrastructure automation from spec through build. Covers requirements, feasibility, design, build, as-built documentation, FlowAgent, IAG, and MOP.",
-      "version": "1.1.1",
+      "version": "1.3.0",
       "author": {
         "name": "Itential"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "itential-builder",
   "description": "AI agent skills for the Itential Platform — deliver infrastructure automation from spec through build. Covers requirements, feasibility, design, build, as-built documentation, FlowAgent, IAG, and MOP.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Itential"
   },


### PR DESCRIPTION
## Summary

- Bumps `plugin.json` from `1.2.0` → `1.3.0`
- Syncs `marketplace.json` from `1.1.1` → `1.3.0` (was stale by two versions)

Covers the batch merged in this cycle: canvas vertical orientation default, JSON Forms dedicated skill, task GBAC documentation, golden config remediation prohibition, project membership/thumbnail fixes, incomingRefs/childJob gotchas, RBAC visibility guidance, contributing CI rules, and accessControl gotcha.

## Test plan
- [ ] Verify both files read `1.3.0`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)