### PR TITLE
refactor: rename app-json_forms to itential-json-forms, add real form exports

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -949,7 +949,7 @@ data_uri = f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}"
 
 ## JSON Forms
 
-JSON Forms have their own dedicated skill — `app-json_forms`. See that skill for the form structure (`struct` / `schema` / `uiSchema` / `bindingSchema`), the static-enum vs. REST-bound vs. cascading dropdown (aka field dependency) patterns, the full API reference (including the bulk-only DELETE), and the manual-trigger wiring (`legacyWrapper: false`).
+JSON Forms have their own dedicated skill — `itential-json-forms`. See that skill for the form structure (`struct` / `schema` / `uiSchema` / `bindingSchema`), the static-enum vs. REST-bound vs. cascading dropdown (aka field dependency) patterns, the full API reference (including the bulk-only DELETE), and the manual-trigger wiring (`legacyWrapper: false`).
 
 Helper templates for forms still live under `${CLAUDE_PLUGIN_ROOT}/helpers/`:
 - `create-json-form.json` — static-enum dropdowns
@@ -2353,8 +2353,8 @@ Read these first. They have the correct wrapper, required fields, and structure.
 | Create a TextFSM template | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-template-textfsm.json` | `POST /automation-studio/templates` |
 | Create a MOP command template | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-command-template.json` | `POST /mop/createTemplate` |
 | Update a MOP template | `${CLAUDE_PLUGIN_ROOT}/helpers/update/update-command-template.json` | `POST /mop/updateTemplate/{name}` |
-| Create a JSON form (static dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form.json` | `POST /json-forms/forms` — see `app-json_forms` skill |
-| Create a JSON form (REST-bound or cascading dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form-rest-bound.json` | `POST /json-forms/forms` — see `app-json_forms` skill |
+| Create a JSON form (static dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form.json` | `POST /json-forms/forms` — see `itential-json-forms` skill |
+| Create a JSON form (REST-bound or cascading dropdowns) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form-rest-bound.json` | `POST /json-forms/forms` — see `itential-json-forms` skill |
 | Create an Ops Manager automation | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-ops-manager-automation.json` | `POST /operations-manager/automations` |
 | Create a manual trigger (with form) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-ops-manager-trigger-manual.json` | `POST /operations-manager/triggers` — `legacyWrapper` MUST be false |
 | Create a scheduled trigger | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-ops-manager-trigger-schedule.json` | `POST /operations-manager/triggers` |

--- a/.claude/skills/itential-json-forms/SKILL.md
+++ b/.claude/skills/itential-json-forms/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: app-json_forms
+name: itential-json-forms
 description: Build IAP JSON Forms — static-enum dropdowns, REST-bound dropdowns (live data pulled from IAP endpoints), and cascading dropdowns (aka field dependency — one field's value drives another's URL path param). Use when creating, updating, or wiring forms consumed by manual triggers, manual tasks (ShowJsonForm), or any UI surface that needs a structured input panel.
 argument-hint: "[form name or operation]"
 ---
 
-# JSON Forms (app-json_forms)
+# JSON Forms (itential-json-forms)
 
 JSON Forms are reusable form definitions stored in the `json-forms` application. They drive structured input panels across IAP — manual triggers in Operations Manager, the `JsonForms/ShowJsonForm` manual task, and any workflow surface that prompts a user for typed input.
 
@@ -38,12 +38,13 @@ POST /json-forms/forms
 
 Choose the helper that matches your form's dropdown needs:
 
-| Use case | Helper |
-|---|---|
-| Static-enum dropdowns only (hardcoded option lists) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form.json` |
-| REST-bound or cascading dropdowns (live data from IAP endpoints) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form-rest-bound.json` |
+| Use case | Annotated scaffold (fill in the blanks) | Real export (read to see the actual shape) |
+|---|---|---|
+| Static-enum dropdowns only (hardcoded option lists) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form.json` | `${CLAUDE_PLUGIN_ROOT}/helpers/assets/json-form-example-static-enum.json` — real Cisco IOS "Port Turn Up" form, 8 fields incl. static dropdown, number `updown` widgets, `ipv4` format validation |
+| REST-bound dropdowns (live data from IAP endpoints) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form-rest-bound.json` | `${CLAUDE_PLUGIN_ROOT}/helpers/assets/json-form-example-rest-bound.json` — real Cisco IOS "Compliance" form, one REST-bound dropdown pulling tree names live from `GET /configuration_manager/configs` |
+| Cascading dropdowns (field dependency) | `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-json-form-rest-bound.json` (Inventory Manager Site/Device cascade worked example) | *(no real cascading export on hand yet — the scaffold is hand-built but follows the same field shapes as the two real exports above)* |
 
-Both helpers are annotated scaffolds — read the `_comment_*` fields inline before customizing.
+The scaffolds are annotated with `_comment_*` fields to fill in; the real exports are genuine `POST /json-forms/forms` payloads pulled from a live platform (IDs/timestamps/`createdBy` stripped since the server assigns those on create) — read one when you want to see exactly what a working form looks like end-to-end, not just the shape.
 
 ### Static-enum dropdowns
 
@@ -140,6 +141,8 @@ Helper for the wired-up trigger: `${CLAUDE_PLUGIN_ROOT}/helpers/create/create-op
 
 - `builder-agent` for workflows that consume form output, manual-trigger wiring, and project-level component management.
 - Helper files in `${CLAUDE_PLUGIN_ROOT}/helpers/`:
-  - `create-json-form.json` — static-enum scaffold
-  - `create-json-form-rest-bound.json` — REST-bound + cascading scaffold (Inventory Manager Site/Device cascade worked example)
-  - `create-ops-manager-trigger-manual.json` — manual trigger that consumes a form
+  - `create/create-json-form.json` — static-enum scaffold
+  - `create/create-json-form-rest-bound.json` — REST-bound + cascading scaffold (Inventory Manager Site/Device cascade worked example)
+  - `create/create-ops-manager-trigger-manual.json` — manual trigger that consumes a form
+  - `assets/json-form-example-static-enum.json` — real export, static-enum (Cisco IOS Port Turn Up)
+  - `assets/json-form-example-rest-bound.json` — real export, REST-bound (Cisco IOS Compliance)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Each skill owns a domain. **Invoke the skill using the Skill tool before working
 | `/itential-golden-config` | — | Golden config, compliance, grading, remediation. |
 | `/itential-inventory` | — | Device inventories, nodes, actions, tags. |
 | `/itential-lcm` | — | Resource models, instances, lifecycle actions. |
+| `/itential-json-forms` | — | JSON Forms: static-enum, REST-bound, and cascading dropdowns for manual triggers and manual tasks. |
 
 ### Delivery Lifecycle
 
@@ -330,6 +331,15 @@ After import, PATCH membership immediately (see Rule 11a).
 | File | What's Inside |
 |------|--------------|
 | `flowagent-sample-agent-project.json` | Real FlowAI project bundle exported from a live platform: 3 agents, including a multi-tool agent (device command → decorated ServiceNow tool → WorkCenter approval step). Import via `POST /agent-project-service/project-bundles/import` with `{"bundle": <file contents>, "providerResolutions": {...}}` — see the `flowagent` skill. |
+
+**JSON Form samples** — different domain, different import path (`POST /json-forms/forms` directly, not Automation Studio project import):
+
+| File | What's Inside |
+|------|--------------|
+| `json-form-example-static-enum.json` | Real Cisco IOS "Port Turn Up" form export: 8 fields incl. a static-enum dropdown, number `updown` widgets, `ipv4` format validation. No REST binding. |
+| `json-form-example-rest-bound.json` | Real Cisco IOS "Compliance" form export: one REST-bound dropdown pulling tree names live from `GET /configuration_manager/configs`, plus one plain text field. |
+
+Both extracted from real, working `jsonForm`-type components inside `vendor-cisco-ios.json` — see the `itential-json-forms` skill for the full form-structure reference.
 
 **Itential Platform — core utilities**
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See [`docs/quickstart.md`](docs/quickstart.md) for the full setup and first deli
 | `/itential-builder:itential-golden-config` | Builds golden config trees and node-level config specs that define the expected configuration standard for your devices. Runs compliance plans, grades results, and generates remediation configs for violations. |
 | `/itential-builder:itential-inventory` | Builds and manages device inventories in Itential Inventory Manager. Populates nodes in bulk, assigns tags, runs actions against inventory devices, and manages inventory-level access and grouping. |
 | `/itential-builder:itential-lcm` | Defines reusable service resource models in Itential Lifecycle Manager, creates and manages resource instances, runs lifecycle actions, and tracks execution history. Use for service models that have create, update, and delete lifecycle phases. |
+| `/itential-builder:itential-json-forms` | Builds IAP JSON Forms — static-enum dropdowns, REST-bound dropdowns (live data from IAP endpoints), and cascading dropdowns (field dependency). Use when wiring structured input panels for manual triggers or manual tasks. |
 
 ---
 

--- a/helpers/assets/json-form-example-rest-bound.json
+++ b/helpers/assets/json-form-example-rest-bound.json
@@ -1,0 +1,119 @@
+{
+  "_comment": "Real JSON Form export (Cisco IOS Compliance form) -- one REST-bound dropdown (tree_name, pulled live from GET /configuration_manager/configs) plus one plain text field. Source: helpers/assets/vendor-cisco-ios.json. IDs/timestamps/createdBy stripped since the server assigns those on create.",
+  "_usage": "POST /json-forms/forms",
+  "name": "Compliance Form",
+  "description": "",
+  "struct": {
+    "type": "array",
+    "items": [
+      {
+        "nodeId": "9b87dfbf-4dca-4a5b-b521-48d45db4fe19",
+        "type": "string",
+        "title": "Tree Name",
+        "description": "",
+        "placeholder": "Select an item",
+        "required": true,
+        "enum": [],
+        "enumNames": [],
+        "binding": true,
+        "rel": "collection",
+        "targetPointer": "/enum",
+        "method": "GET",
+        "uniqueItems": false,
+        "base": "/configuration_manager",
+        "href": "/configs",
+        "sourcePointer": "/",
+        "sourceKeyPointer": "/name",
+        "customKey": "tree_name"
+      },
+      {
+        "nodeId": "c255ed38-8022-4f08-b277-30fbf0fd0a86",
+        "type": "string",
+        "title": "Tree Version",
+        "description": "",
+        "placeholder": "Enter text",
+        "required": true,
+        "readOnly": false,
+        "binding": false,
+        "rel": "item",
+        "targetPointer": "/default",
+        "customKey": "version",
+        "default": "initial"
+      }
+    ]
+  },
+  "schema": {
+    "title": "Compliance Form",
+    "description": "",
+    "type": "object",
+    "required": [
+      "tree_name",
+      "version"
+    ],
+    "properties": {
+      "tree_name": {
+        "type": "string",
+        "title": "Tree Name",
+        "_id": "/properties/tree_name",
+        "description": "",
+        "enum": [],
+        "enumNames": []
+      },
+      "version": {
+        "type": "string",
+        "title": "Tree Version",
+        "_id": "/properties/version",
+        "description": "",
+        "default": "initial"
+      }
+    }
+  },
+  "uiSchema": {
+    "tree_name": {
+      "ui:placeholder": "Select an item"
+    },
+    "version": {
+      "ui:placeholder": "Enter text"
+    },
+    "ui:order": [
+      "tree_name",
+      "version",
+      "*"
+    ]
+  },
+  "bindingSchema": {
+    "properties": {
+      "tree_name": {
+        "binding:method": "GET",
+        "binding:link": {
+          "$ref": "/links",
+          "rel": "collection"
+        },
+        "binding:target": {
+          "propertyPointer": "/enum"
+        },
+        "binding:hyperSchema": {
+          "type": "object",
+          "base": "/configuration_manager",
+          "links": [
+            {
+              "rel": "collection",
+              "href": "/configs",
+              "targetMediaType": "application/json",
+              "targetSchema": {
+                "$ref": "#"
+              },
+              "variables": []
+            }
+          ]
+        },
+        "binding:source": {
+          "propertyPointer": "/",
+          "keyPointer": "/name"
+        }
+      }
+    }
+  },
+  "validationSchema": {},
+  "version": "2020.1"
+}

--- a/helpers/assets/json-form-example-static-enum.json
+++ b/helpers/assets/json-form-example-static-enum.json
@@ -1,0 +1,258 @@
+{
+  "_comment": "Real JSON Form export (Cisco IOS Port Turn Up form) -- static-enum dropdowns only, no REST binding. Source: helpers/assets/vendor-cisco-ios.json. IDs/timestamps/createdBy stripped since the server assigns those on create.",
+  "_usage": "POST /json-forms/forms",
+  "name": "Port Turn Up Form",
+  "description": "",
+  "struct": {
+    "type": "array",
+    "items": [
+      {
+        "nodeId": "cb06b02f-e05d-40fd-9274-4d9d6e54f4f2",
+        "type": "string",
+        "title": "Device",
+        "description": "",
+        "placeholder": "Enter text",
+        "required": true,
+        "readOnly": false,
+        "binding": false,
+        "rel": "item",
+        "targetPointer": "/default",
+        "customKey": "device",
+        "default": "Itential Lab Main::aws-lab-iosxe"
+      },
+      {
+        "nodeId": "0651cf6c-8225-4110-b3d0-9a178b84a275",
+        "type": "string",
+        "title": "Type",
+        "description": "",
+        "placeholder": "Select an item",
+        "required": true,
+        "enum": [
+          {
+            "id": "5570e66c-3e91-46a2-9d65-b196e6a08199",
+            "label": "GigabitEthernet",
+            "value": "GigabitEthernet"
+          }
+        ],
+        "enumNames": [
+          {
+            "id": "195c6ab1-aac1-4b2f-809c-36e7ed23d889",
+            "label": "",
+            "value": ""
+          }
+        ],
+        "binding": false,
+        "rel": "collection",
+        "targetPointer": "/enum",
+        "default": "GigabitEthernet"
+      },
+      {
+        "nodeId": "9273e8e2-f405-40d6-84b2-c6f1bbc03460",
+        "type": "number",
+        "widget": "updown",
+        "title": "Interface",
+        "description": "",
+        "placeholder": "Enter a number",
+        "required": true,
+        "minimum": 1,
+        "maximum": 1,
+        "default": 1
+      },
+      {
+        "nodeId": "8f1702b6-cc4b-4c8c-83b5-9ba0fd2ac248",
+        "type": "number",
+        "widget": "updown",
+        "title": "Sub Interface",
+        "description": "",
+        "placeholder": "Enter a number",
+        "required": true,
+        "customKey": false,
+        "minimum": 100,
+        "maximum": 300,
+        "default": 100
+      },
+      {
+        "nodeId": "84d89275-8fb2-49eb-a105-a77a509c7a98",
+        "type": "string",
+        "title": "Description",
+        "description": "",
+        "placeholder": "Enter text",
+        "required": true,
+        "readOnly": false,
+        "binding": false,
+        "rel": "item",
+        "targetPointer": "/default",
+        "default": "test"
+      },
+      {
+        "nodeId": "481540c4-815e-42f9-a899-506c3d446059",
+        "type": "string",
+        "title": "IP Address",
+        "description": "",
+        "placeholder": "Enter text",
+        "required": false,
+        "readOnly": false,
+        "binding": false,
+        "rel": "item",
+        "targetPointer": "/default",
+        "format": "ipv4",
+        "default": "10.0.0.2"
+      },
+      {
+        "nodeId": "32fafb5d-a7ec-4124-8d10-c6cf61f2ff31",
+        "type": "string",
+        "title": "Subnet Mask",
+        "description": "",
+        "placeholder": "Enter text",
+        "required": true,
+        "readOnly": false,
+        "binding": false,
+        "rel": "item",
+        "targetPointer": "/default",
+        "format": "ipv4",
+        "default": "255.255.255.0"
+      },
+      {
+        "nodeId": "c2d5ef38-9906-4512-a124-8e1aff1d019a",
+        "type": "number",
+        "widget": "updown",
+        "title": "VLAN",
+        "description": "",
+        "placeholder": "Enter a number",
+        "required": true,
+        "minimum": 100,
+        "maximum": 300,
+        "default": 100
+      }
+    ]
+  },
+  "schema": {
+    "title": "Port Turn Up Form",
+    "description": "",
+    "type": "object",
+    "required": [
+      "device",
+      "type",
+      "interface",
+      "subInterface",
+      "description",
+      "subnetMask",
+      "vlan"
+    ],
+    "properties": {
+      "device": {
+        "type": "string",
+        "title": "Device",
+        "_id": "/properties/device",
+        "description": "",
+        "default": "Itential Lab Main::aws-lab-iosxe"
+      },
+      "type": {
+        "type": "string",
+        "title": "Type",
+        "_id": "/properties/type",
+        "description": "",
+        "default": "GigabitEthernet",
+        "enum": [
+          "GigabitEthernet"
+        ],
+        "enumNames": [
+          ""
+        ]
+      },
+      "interface": {
+        "type": "number",
+        "title": "Interface",
+        "_id": "/properties/interface",
+        "description": "",
+        "default": 1,
+        "minimum": 1,
+        "maximum": 1
+      },
+      "subInterface": {
+        "type": "number",
+        "title": "Sub Interface",
+        "_id": "/properties/subInterface",
+        "description": "",
+        "default": 100,
+        "minimum": 100,
+        "maximum": 300
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "_id": "/properties/description",
+        "description": "",
+        "default": "test"
+      },
+      "ipAddress": {
+        "type": "string",
+        "title": "IP Address",
+        "_id": "/properties/ipAddress",
+        "description": "",
+        "default": "10.0.0.2",
+        "format": "ipv4"
+      },
+      "subnetMask": {
+        "type": "string",
+        "title": "Subnet Mask",
+        "_id": "/properties/subnetMask",
+        "description": "",
+        "default": "255.255.255.0",
+        "format": "ipv4"
+      },
+      "vlan": {
+        "type": "number",
+        "title": "VLAN",
+        "_id": "/properties/vlan",
+        "description": "",
+        "default": 100,
+        "minimum": 100,
+        "maximum": 300
+      }
+    }
+  },
+  "uiSchema": {
+    "device": {
+      "ui:placeholder": "Enter text"
+    },
+    "type": {
+      "ui:placeholder": "Select an item"
+    },
+    "interface": {
+      "ui:placeholder": "Enter a number",
+      "ui:widget": "updown"
+    },
+    "subInterface": {
+      "ui:placeholder": "Enter a number",
+      "ui:widget": "updown"
+    },
+    "description": {
+      "ui:placeholder": "Enter text"
+    },
+    "ipAddress": {
+      "ui:placeholder": "Enter text"
+    },
+    "subnetMask": {
+      "ui:placeholder": "Enter text"
+    },
+    "vlan": {
+      "ui:placeholder": "Enter a number",
+      "ui:widget": "updown"
+    },
+    "ui:order": [
+      "device",
+      "type",
+      "interface",
+      "subInterface",
+      "description",
+      "ipAddress",
+      "subnetMask",
+      "vlan",
+      "*"
+    ]
+  },
+  "bindingSchema": {},
+  "validationSchema": {},
+  "version": "2020.1"
+}


### PR DESCRIPTION
## Summary
- Renamed `.claude/skills/app-json_forms` → `.claude/skills/itential-json-forms` to match every other domain skill's naming convention (`itential-<feature>`, kebab-case) — it was the only skill still using the old `app-<name>` / underscore pattern.
- The skill was also entirely missing from `AGENTS.md`'s Skill Router table and the top-level `README.md`'s Platform skills table — added it to both.
- Updated the two stale references to the old name in `builder-agent/SKILL.md`.
- Added two real JSON Form exports as `helpers/assets/` files, extracted from the genuine `jsonForm`-type components already inside `helpers/assets/vendor-cisco-ios.json` (IDs/timestamps/`createdBy` stripped since the server assigns those on create):
  - `json-form-example-static-enum.json` — real 8-field "Port Turn Up" form (static dropdown, number `updown` widgets, `ipv4` format validation, no REST binding)
  - `json-form-example-rest-bound.json` — real "Compliance" form with a live REST-bound dropdown pulling tree names from `GET /configuration_manager/configs`

These sit alongside the existing hand-authored `create-json-form*.json` scaffolds — the skill now points to both an annotated fill-in-the-blanks template and a genuine, previously-real working example for each dropdown pattern.

## Testing
- [x] Confirmed no remaining references to `app-json_forms` / `app-json-forms` anywhere in the repo
- [x] Validated both new helper JSON files parse correctly
- [x] `git mv` used for the rename to preserve file history

## Related
No cascading-dropdown real export was available to extract (none of the existing vendor asset bundles have one) — the hand-authored cascade scaffold in `create-json-form-rest-bound.json` remains the only reference for that pattern.