### PR TITLE
feat(iag4-to-iag5): add migration readiness assessment skill

### DIFF
--- a/.claude/skills/iag4-to-iag5/SKILL.md
+++ b/.claude/skills/iag4-to-iag5/SKILL.md
@@ -458,17 +458,20 @@ Fill `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-temp
 `<working-dir>/iag4-to-iag5-readiness.md` (the report is the **only** file in the working-dir
 root — all pulled JSON and scratch stay in `tmp/`).
 
-**Analysis vs. recommendations — the split (important).** The **analysis** sections — Workflows,
-JSON Forms, Inventory — are **pure facts**: what is on the platform, nothing inferred, nothing
-recommended. NO per-task "what to do", NO remediation codes, NO legend. The only forward-looking /
-suggested content lives in the **two clearly-labelled sections at the end**: Recommended Repository
-Structure and Manual Action Checklist. Never put recommendation text into the analysis tables.
+**Recommendations via short CODES + one static legend.** Each Gateway4 task carries a short
+remediation code — **WRAP / REVIEW / ARGS / INV** — computed by the analyzer (`code` per task,
+`codes` per workflow). Explain them ONCE in a static **Recommended Actions** legend section; the
+Workflows tables show only the code (never the full sentence). The full recommendation text lives in
+the legend and the end Manual Action Checklist. Codes are a best-effort classification from each
+task's name/description — the legend says "review each", so this is honest guidance, not asserted
+fact. Do NOT write the full recommendation sentence into the Workflows tables.
 
-**Section order (fixed) + Table of Contents.** Render sections in this order: **Summary, Workflows,
-JSON Forms, Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure, Manual Action
-Checklist** — the checklist is **last**, after the repo section. Immediately under the header table,
-emit a `## Contents` table-of-contents with one linked entry per section (GitHub-style anchors, e.g.
-`[Scripts, Playbooks & Roles](#scripts-playbooks--roles)`) so the reader can jump around.
+**Section order (fixed) + Table of Contents.** Render sections in this order: **Summary, Recommended
+Actions, Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory, Recommended Repository
+Structure, Manual Action Checklist** — the checklist is **last**, after the repo section. Immediately
+under the header table, emit a `## Contents` table-of-contents with one linked entry per section
+(GitHub-style anchors, e.g. `[Scripts, Playbooks & Roles](#scripts-playbooks--roles)`) so the reader
+can jump around.
 
 **WORDING — the rendered report must NOT contain "iag"/"IAG4"/"IAG5" (req d).** Use "Itential
 Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5". Keep literal API/app names
@@ -490,20 +493,24 @@ part of the file's content). If it matches, fix the wording before telling the u
   `> **Warning:** …` lines. Never invent what a warned-about workflow contains (rule 2).
 - **Summary** counts ← `counts` (`n_workflows`, `n_gw4_tasks` ← `counts.n_iag4_tasks`, `n_forms`,
   `n_gw4_devices` ← `counts.n_iag4_devices`), plus `n_unresolved` ← `unresolved_children` length.
-- **Workflows** section ← `workflow_groups[]` (already ordered) — **PURE FACTS, no
-  recommendations/codes**. **Grouped by location**: iterate `workflow_groups` (projects first by
-  name, then a final `Global` group; workflows within each already name-sorted). Do NOT re-sort.
+- **Recommended Actions** — the static legend table (WRAP / REVIEW / ARGS / INV). Render the
+  "Recommended action" cells VERBATIM from the template (they mirror the analyzer's `REC_BY_CODE`);
+  do not reword. Include the "codes are a best-effort classification — review each" line.
+- **Workflows** section ← `workflow_groups[]` (already ordered). **Grouped by location**: iterate
+  `workflow_groups` (projects first by name, then a final `Global` group; workflows within each
+  already name-sorted). Do NOT re-sort.
   - **Group headline** — `### {group.label}` where `label` is `«project_name» (project_id)` for a
     project or `Global`. The project/Global identity lives HERE, so it is **not** repeated below
     (no "Scope / Connector" column, no location in the detail heading — kills the repeated text).
-  - **Per-group index table** — one row per workflow in the group: `Workflow | Tasks | Interface(s) |
-    ID` = `` `workflow_name` | n_tasks | interfaces | `workflow_id` ``. `interfaces` ← the workflow's
-    `interfaces` array (distinct, task order) joined `, ` — factual `AG Manager` and/or actual adapter
-    name(s), for cluster mapping. **Always print `workflow_id`** — disambiguates same-named clones.
-  - **Detail section** (one per workflow in the group) — `#### \`workflow_name\` · \`workflow_id\``
-    (no location) then a **3-col** table, one row per task: `Task | Name | Interface` =
-    `` `task_id` | task_name | interface ``. `interface` (req a) is `AG Manager` or the actual adapter
-    name (verbatim). No recommendation column.
+  - **Per-group index table** — one row per workflow: `Workflow | Tasks | Interface(s) | Rec | ID` =
+    `` `workflow_name` | n_tasks | interfaces | codes | `workflow_id` ``. `interfaces` ← distinct
+    `interfaces` (task order) — factual `AG Manager` and/or adapter name(s), for cluster mapping.
+    `codes` ← the workflow's distinct `codes` (CODE_ORDER) joined `, ` (e.g. `WRAP, ARGS`) — the
+    short recommendation codes from the legend. **Always print `workflow_id`** — disambiguates clones.
+  - **Detail section** (one per workflow) — `#### \`workflow_name\` · \`workflow_id\`` (no location)
+    then a **4-col** table, one row per task: `Task | Name | Interface | Rec` = `` `task_id` |
+    task_name | interface | code ``. `interface` (req a) is `AG Manager` or the actual adapter name
+    (verbatim); `code` is the task's short remediation code (full text in the legend, NOT here).
   - **References** — collect the relationship lines in order: (1) if `called_by` (req c) non-empty,
     `` Called by `name` (`id`), … `` (in-scope parents only); (2) for each task whose `referenced_by`
     (req b) is non-empty, `` `task_id` output used by `id`, `id` ``. Zero lines → render nothing.
@@ -520,8 +527,11 @@ part of the file's content). If it matches, fix the wording before telling the u
   the recommendation** — do not make it conditional on service count, and do not print any service
   counts anywhere in this section (no "small team / < 20 services" qualifiers on the option
   headings either). In the Option A tree, emit one leaf per service foldered by domain, each
-  annotated `← was <original> (<iag4_type>)`; python-script leaves get `main.py` +
-  `requirements.txt`, ansible-playbook leaves get `playbook.yml`. Fill the Naming Conventions
+  annotated `← was <original> (<iag4_type>)`. File layout by code/type: **ARGS** (python-script) and
+  **WRAP** (collection-or-role) leaves become python services → `main.py` + `requirements.txt`;
+  **REVIEW** (ansible-playbook) leaves → `playbook.yml`. **INV** (self-management) tasks are NOT
+  services — they move to Inventory Manager, so **exclude them from the repo tree**. Fill the Naming
+  Conventions
   "Examples" column with the actual service names mapped to `{team}-{domain}-{action}`. **Use
   placeholder team names `team1`, `team2`, … (one team per domain in B/C) — never assume real team
   names.** Domains are still derived from the services. Keep the option headings verbatim: `Option
@@ -533,11 +543,10 @@ part of the file's content). If it matches, fix the wording before telling the u
 - **Manual Action Checklist** — the **last** section — **grouped by item type**, each group under its
   own `###` subheading, in fixed order: **Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory,
   General**. **Render only groups that have items — drop an empty group entirely.**
-  - **Workflows** ← `checklist.workflows` (already sorted by recommendation then name, so identical
-    recommendations cluster). Each item is **self-contained** — it carries its own recommendation
-    text, so no legend is needed: `` - [ ] `key` (app_display, N task/tasks) — recommendation ``. Use
+  - **Workflows** ← `checklist.workflows` (already sorted by code then name — WRAP, REVIEW, ARGS, INV
+    — so same-recommendation items cluster). Each item is **self-contained** — it carries its own
+    recommendation text: `` - [ ] `key` (app_display, N task/tasks) — recommendation ``. Use
     `app_display` (already `AG Manager` or the adapter type) and pluralize `task`/`tasks` on `count`.
-    No codes, no divergence note.
   - **JSON Forms** ← `checklist.forms`. **Scripts, Playbooks & Roles** ← the Step 4 assets.
   - **Inventory** ← flagged devices from `analysis.json → devices` (one `- [ ]` per device) plus the
     gateway built-in-inventory action (Step 5b); scoped/local run where devices weren't pulled →

--- a/.claude/skills/iag4-to-iag5/SKILL.md
+++ b/.claude/skills/iag4-to-iag5/SKILL.md
@@ -608,7 +608,7 @@ that `tmp/` is read-cache/scratch and safe to delete.
   Route actual builds to `/iag`.
 
 ## See also
-- `/iag` — building IAG5 services (Python/Ansible/OpenTofu), service YAML, `runService` wiring.
+- `/iag` — building IAG5 service(s) (Python/Ansible/OpenTofu), service YAML, `runService` wiring.
 - `/itential-inventory` — Inventory Manager, the IAG5 replacement for gateway inventory.
 - `/itential-json-forms` — REST-bound dropdown structure and `bindingSchema`.
 - `/explore` — auth + IAP pull mechanics reused in Step 1.

--- a/.claude/skills/iag4-to-iag5/SKILL.md
+++ b/.claude/skills/iag4-to-iag5/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iag4-to-iag5
-description: Assess how ready an environment is to move from Itential Automation Gateway 4 (IAG4) to IAG5. Use for phrases like "am I ready to move to IAG5", "assess my IAG4 to IAG5 migration", "what do I need to change to switch off gateway 4", "scan my workflows for automation gateway usage", "which workflows use IAG4", "IAG4 readiness report", or "evaluate my gateway migration". This skill does NOT perform the migration — it analyzes IAP assets (workflows in and out of projects, JSON forms) and IAG4 assets (scripts, playbooks, roles, inventory), then writes a deterministic markdown guideline of the manual actions the user must take. It is strictly READ-ONLY against IAP and IAG — it never creates, updates, or deletes anything on the platform; its only write is the report in the working directory. For actually building IAG5 services, use /iag.
+description: Assess how ready an environment is to move from Itential Automation Gateway 4 (IAG4) to IAG5. Use for phrases like "am I ready to move to IAG5", "assess my IAG4 to IAG5 migration", "what do I need to change to switch off gateway 4", "scan my workflows for automation gateway usage", "which workflows use IAG4", "IAG4 readiness report", or "evaluate my gateway migration". This skill does NOT perform the migration — it analyzes IAP assets (workflows in and out of projects, JSON forms) and IAG4 assets (scripts, playbooks, roles, inventory), then writes a deterministic markdown guideline of the manual actions the user must take. It is strictly READ-ONLY against IAP and IAG — it never creates, updates, or deletes anything on the platform; its only write is the report in the working directory. It can also run in a LOCAL-FILES-ONLY mode with no API access. The rendered report uses the terms "Itential Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5" (never "IAG"). For actually building IAG5 services, use /iag.
 argument-hint: "[working-directory]"
 ---
 
@@ -11,6 +11,38 @@ argument-hint: "[working-directory]"
 **Produces:** `<working-dir>/iag4-to-iag5-readiness.md` — one deterministic markdown report. All
 pulled JSON, the auth cache, and scratch files go under `<working-dir>/tmp/` — never the
 working-dir root. Only the report lives in the root.
+
+## NON-NEGOTIABLE RULES (never break these)
+
+These four rules override everything else. If following any other instruction would violate one of
+them, STOP and ask the user instead.
+
+1. **Strictly read-only on IAP and Gateway4.** No create/update/delete/import/patch — no
+   state-mutating `POST/PUT/PATCH/DELETE`, no writing workflows/forms/projects/inventory/gateway
+   assets. The ONLY write is the report (and read-cache JSON) in the working directory. Anything that
+   would mutate a platform is recorded in the report as a manual action, never executed.
+   **Gateway4 assets (scripts, playbooks, roles, inventory) come from ONE of two sources:** (a) a
+   **local directory** in the working dir, or (b) **Gateway4's own HTTP API** when the user provides
+   Gateway4 credentials (username/password) — read-only GETs only. Use whichever the user has; if
+   neither, ask. **Never contact Gateway5, and never use `iagctl`** — `iagctl` is a Gateway5 CLI (it
+   does not exist on Gateway4). Gateway5 is entirely out of scope and must never be contacted or
+   mentioned to the user.
+2. **Never make up information, and never contact Gateway5 directly.** Do NOT guess identifiers,
+   task classifications, workflow/task references, adapter names, or the contents of anything you
+   could not read. If something is unknown, ambiguous, or unreadable, **go back to the user to
+   clarify** — do not invent, infer, or fill in a plausible value. The analyzer's
+   `unresolved_children`/`warnings` exist precisely so unknowns are surfaced, not fabricated.
+   Gateway5 is out of scope — never call it, `iagctl`, or any Gateway5 endpoint, and never mention it.
+3. **Respect the scan scope absolutely.** When the user points you at a project or specific
+   workflow(s) (anything other than an explicit `--all`), analyze ONLY that item **plus** any other
+   workflow/project it (or its children) references via childJob — the transitive downward closure.
+   Do NOT look at, pull, or report on anything else on the platform. Referenced children may live in
+   the global space or in other projects; those are in scope only because they are referenced.
+4. **Scoped pulls only, and support local-only.** Never bulk-pull the whole platform for a scoped
+   run. Pull exactly the requested item, then follow references. If the user gives no API access (or
+   asks to analyze only local files), run in **local-files-only mode** against the working directory
+   — no API calls at all. When something referenced cannot be resolved (not pullable, not on disk),
+   emit a **last-resort warning** in the report; never substitute a guess.
 
 ## What this does (and does NOT do)
 
@@ -33,15 +65,19 @@ report. Keep every recommendation to a **manual action the user performs themsel
 
 ### Read-only guarantee (hard rule)
 
-This skill is **read-only against IAP and IAG**. Its ONLY write target is the **working
+This skill is **read-only against IAP and Gateway4**. Its ONLY write target is the **working
 directory** (the report, plus any pulled read-cache JSON).
-- **Allowed:** auth (`/oauth/token`, `/login`), read/discovery **GET**s (workflows, json-forms,
-  projects export, apps, adapters), the POST-based **devices read** if needed; on IAG, only
-  read-only `iagctl get/describe/db export` or local files.
-- **Forbidden:** any create/update/delete/import/patch on IAP or IAG — no state-mutating
-  `POST/PUT/PATCH/DELETE`, no `iagctl db import`, no writing services, no editing/creating
-  workflows, forms, projects, inventory, or gateway config. If a step *would* mutate the
-  platform, **do not do it** — record it in the report as a manual action for the user.
+- **Allowed:** IAP auth (`/oauth/token`, `/login`), IAP read/discovery **GET**s (workflows,
+  json-forms, projects export, apps, adapters), the POST-based **devices read** if needed; Gateway4
+  assets (scripts/playbooks/roles/inventory) from **either** a **local directory** the user supplies
+  **or** read-only GETs against **Gateway4's HTTP API** when the user provides Gateway4
+  username/password.
+- **Forbidden:** any create/update/delete/import/patch on IAP or Gateway4 — no state-mutating
+  `POST/PUT/PATCH/DELETE`, no editing/creating workflows, forms, projects, inventory, or gateway
+  assets. **Never contact Gateway5 and never use `iagctl`** — `iagctl` is a Gateway5 CLI and does
+  not exist on Gateway4; Gateway5 is out of scope (do not call it and do not mention it to the user).
+  If a step *would* mutate a platform, **do not do it** — record it in the report as a manual
+  action for the user.
 
 These two rules are agent guidance — they shape the recommendations but are **not** printed in
 the report (the report is a terse checklist, not a narrative):
@@ -79,28 +115,44 @@ Same inputs ⇒ identical report. Enforce:
 
 ## Step 0 — Working directory, scope & data sources
 
-**Ask these two up front if the user did not already supply them** (use AskUserQuestion):
+**Ask these up front if the user did not already supply them** (use AskUserQuestion):
 
 1. **Working directory** — where the report is written. If the user passed one as an argument,
    use it; else ask.
-2. **Scan scope** — the workflow analysis (Step 2) is driven by one of three deterministic
-   scopes; ask which the user wants and carry it into the script flag:
+2. **Scan scope** — the workflow analysis (Step 2) is driven by one of three deterministic scopes.
+   A scoped run is the DEFAULT; carry the choice into the script flag. The scope is the **seed** —
+   the analyzer then follows childJob references DOWN into the transitive closure (rule 3), so a
+   scoped run still covers every workflow the seed reaches, and **only** those:
    - **project(s)** → `--projects <id,id>` (recommended — one or more project ids)
    - **explicit workflow list** → `--workflows "Name A;Name B"`
-   - **all workflows** → `--all` — **not recommended**: on a large platform this scans every
-     workflow (here 1504) and can overflow a small model's context window. Only use if the user
-     explicitly asks.
+   - **all workflows** → `--all` — **not recommended**: bulk-scans every workflow on the platform
+     (e.g. 1504) and can overflow a small model's context window. Only use if the user explicitly
+     asks. `--all` is the ONLY mode that pulls the whole platform; every other scope pulls just the
+     seed + referenced children.
+3. **Data source per platform.** There are TWO platforms this skill can read — **IAP** and
+   **Gateway4** — and EACH can be sourced either **live (read-only HTTP API)** or **local files**.
+   Ask the user (never assume); any combination is valid (IAP-only, Gateway4-only, or both; live,
+   local, or mixed):
+   - **IAP** — **live** (scoped read-only API pulls) or **local IAP JSON** (workflow/project/form
+     exports already on disk), or none.
+   - **Gateway4** — **live** (read-only GETs against Gateway4's HTTP API using the username/password
+     the user provides) or a **local directory** of scripts/playbooks/roles/inventory, or none.
+   - **Never** offer, ask about, or use `iagctl` or any Gateway5 endpoint — Gateway5 is out of scope
+     (`iagctl` is a Gateway5 CLI and does not exist on Gateway4).
+   - When a source is fully local, pass `--local` (and `--local-dir <dir>`) to the analyzer; it makes
+     no API calls for that source. Anything referenced but not readable becomes a last-resort
+     warning — never a guess.
 
 Then establish the data sources:
 
-3. **Never assume the source of assets.** Look for a `.env` in the working dir (the auth cache
-   lives at `tmp/.auth.json`).
-   - If a `.env` exists, determine whether it targets **IAP only, IAG only, or both**. If the
-     file's purpose is unclear, **ask the user** — do not guess.
-   - Ask (or confirm) what the user has: local IAP asset JSON, live IAP access, local IAG4
-     assets, live IAG4 access — any combination, including IAP-only or IAG4-only.
-4. Establish each source as `live`, `local`, or `none`. **Local files take precedence** over
-   live pulls when both exist. Record all of this for the report header.
+4. **Never assume the source of assets.** Look for a `.env` in the working dir (the auth cache
+   lives at `tmp/.auth.json`). A `.env` may carry **IAP** creds and/or **Gateway4** creds — check
+   which it has; if its purpose is unclear, ask the user.
+   - Confirm, for IAP and for Gateway4 independently, whether the user has **live** access
+     (credentials for read-only API calls) or **local files**, or neither.
+5. Establish each source (IAP, Gateway4) as `live` or `local`. **Local files take precedence** over
+   live pulls when both exist. Record all of this for the report header (`Mode:` = live/local per
+   source).
 
 ## Step 1 — IAP data (only if IAP is in scope)
 
@@ -155,9 +207,13 @@ A workflow is treated as project-owned **only** when its `namespace` says so; a 
 carries a stale `@{id}:` prefix for a deleted project is reported as **Global**, not `name
 unavailable`.
 
-**Devices — for the Inventory check (read-only, POST is a query not a mutation).** So the analyzer
-can tell whether Configuration Manager devices are sourced from an IAG4 gateway adapter, pull the
-device list into `tmp/devices.json`. `POST /configuration_manager/devices` is the "Find Devices"
+**Devices — for the Inventory check (read-only, POST is a query not a mutation). SCOPE-GATED.**
+The device-origin check is **platform-wide**, so it runs ONLY under `--all` (or when the user
+explicitly opts in). In a scoped `--projects`/`--workflows` run, and in local-only mode, **do not
+pull devices** — it is outside the requested scope (rule 3); the report's Inventory device line then
+renders "Skipped — outside scan scope." When it does apply: so the analyzer can tell whether
+Configuration Manager devices are sourced from an IAG4 gateway adapter, pull the device list into
+`tmp/devices.json`. `POST /configuration_manager/devices` is the "Find Devices"
 read query; body `{"options":{"start":0,"limit":100}}`, response shape `{total, list:[...]}` where
 each device carries `origins[]` (the source adapter instances). Paginate on `total`:
 ```bash
@@ -177,32 +233,47 @@ rm -f tmp/devices.page.json
 Skip this only if IAP is out of scope or Configuration Manager is not installed. If `devices.json`
 is absent the analyzer degrades gracefully (reports "device origins not checked").
 
-**Workflows — MUST paginate (the list caps at 100 per page).** A single `?limit=500` silently
-returns only 100 rows while `total` may be far higher (e.g. 1504) — you WILL miss workflows.
-Read `total` from the first page, then loop `skip` in steps of the returned page size, appending
-each page's `items[]`:
-```bash
-total=$(curl -s -H "$AUTH" "{BASE}/automation-studio/workflows?limit=1" | jq .total)
-# FAIL FAST: if `total` is not a number, auth failed (the first call returned an error body, not a
-# workflows page). Do NOT proceed — an empty pull produces a misleading all-zeros report. The #1
-# cause is sending an OAuth token as ?token= instead of the Authorization: Bearer header.
-case "$total" in ''|*[!0-9]*) echo "AUTH/PULL FAILED — workflows 'total' is not numeric ('$total'). Fix auth (OAuth token goes in the Authorization: Bearer HEADER, not ?token=) and re-run." >&2; exit 1;; esac
-skip=0; : > tmp/wf_all.ndjson
-while [ "$skip" -lt "$total" ]; do
-  curl -s -H "$AUTH" "{BASE}/automation-studio/workflows?limit=100&skip=${skip}" \
-    | jq -c '.items[]' >> tmp/wf_all.ndjson
-  skip=$((skip+100))
-done
-# VALIDATE the pull before running the analyzer: the ndjson line count must match `total`. A count of
-# 0 (or well below `total`) means pages 401'd silently — re-auth and re-pull; never analyze a short pull.
-lines=$(wc -l < tmp/wf_all.ndjson)
-[ "$lines" -eq "$total" ] || echo "WARNING: pulled $lines of $total workflows — pull is incomplete (likely mid-run token expiry); re-auth and re-run before analyzing." >&2
-```
-`tmp/wf_all.ndjson` (one workflow doc per line) is the full set — global **and** `@{projectId}:`
-scoped workflows both come back from this list, so scanning it covers both. (If any project's
-workflows are ACL-hidden from the list, export that project via
-`GET /automation-studio/projects/{id}/export` and read `components[]` where
-`type == "workflow"` → `document.tasks`.)
+**Workflows — pull ONLY what the scope needs (rule 4).** Never bulk-pull the whole platform for a
+scoped run. How you pull depends on the Step-0 scope and data source:
+
+- **Local-files-only mode** (no API): do NOT pull anything. The workflow/project-export/form JSON
+  already in the working dir is the input. Skip straight to Step 2 with `--local --local-dir <dir>`
+  (point `--local-dir` at wherever those files live, default `<working-dir>/tmp`).
+
+- **`--projects <id,id>` (live):** export just those projects — read-only —
+  `GET /automation-studio/projects/{id}/export`; take `components[]` where `type == "workflow"` and
+  write each `document` as one ndjson line to `tmp/wf_all.ndjson` (also grab `type == "jsonForm"`
+  components for the in-scope form scan). Stamp each doc's `namespace` with the project `{_id,name}`
+  so location resolves correctly.
+
+- **`--workflows "Name A;Name B"` (live):** fetch just those workflows by name (read-only), e.g.
+  `GET /automation-studio/workflows?equals[name]=<name>` (or the list filtered to the names), and
+  append each returned workflow doc as an ndjson line to `tmp/wf_all.ndjson`.
+
+- **`--all` (live, NOT recommended — the only bulk mode):** paginate the full list (caps at 100/page;
+  `?limit=500` silently returns only 100). Read `total`, loop `skip`, append each page's `items[]`:
+  ```bash
+  total=$(curl -s -H "$AUTH" "{BASE}/automation-studio/workflows?limit=1" | jq .total)
+  # FAIL FAST: non-numeric total = auth failed (error body, not a workflows page). Do NOT proceed —
+  # an empty pull yields a misleading all-zeros report. #1 cause: OAuth token sent as ?token= not header.
+  case "$total" in ''|*[!0-9]*) echo "AUTH/PULL FAILED — workflows 'total' is not numeric ('$total'). Fix auth (OAuth token → Authorization: Bearer HEADER, not ?token=) and re-run." >&2; exit 1;; esac
+  skip=0; : > tmp/wf_all.ndjson
+  while [ "$skip" -lt "$total" ]; do
+    curl -s -H "$AUTH" "{BASE}/automation-studio/workflows?limit=100&skip=${skip}" | jq -c '.items[]' >> tmp/wf_all.ndjson
+    skip=$((skip+100))
+  done
+  lines=$(wc -l < tmp/wf_all.ndjson)
+  [ "$lines" -eq "$total" ] || echo "WARNING: pulled $lines of $total — incomplete (likely mid-run token expiry); re-auth and re-run." >&2
+  ```
+
+**Closure loop (rule 3, live scoped runs only).** After the first analyzer run (Step 2), read
+`analysis.json → unresolved_children`. For each referenced child workflow name not yet in the pool,
+fetch it (by name; if it belongs to a project, export that project) and append to `tmp/wf_all.ndjson`,
+then re-run the analyzer. Repeat until `unresolved_children` is empty **or** no source can resolve
+what remains — anything still unresolved stays in `unresolved_children` and becomes a last-resort
+report warning. This is how a scoped run legitimately reaches into other projects / the global space:
+only via references, never by scanning the whole platform. In **local mode** there is no pull loop —
+resolve children only from the local files; whatever is missing stays a warning.
 
 ## Step 1b — Resolve the IAG4 identifiers
 
@@ -233,24 +304,46 @@ docs out of your context. Run it against the `tmp/` you populated in Step 1, pas
 chosen in Step 0:
 
 ```bash
+# live scoped run:
 python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py \
   --tmp <working-dir>/tmp \
+  { --projects <id,id>  |  --workflows "Name A;Name B"  |  --all }
+# local-files-only run (no API): add --local (and --local-dir if the JSON isn't in tmp/):
+python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py \
+  --tmp <working-dir>/tmp --local --local-dir <dir-of-workflow-json> \
   { --projects <id,id>  |  --workflows "Name A;Name B"  |  --all }
 # writes <working-dir>/tmp/analysis.json
 ```
 
 The script is **read-only** (its only write is `tmp/analysis.json`), needs no network/auth, and
-consumes `tmp/{wf_all.ndjson,adapters.json,apps.json,json-forms.json}`. A missing scope flag exits
-non-zero; a `wf_all.ndjson` that is missing, empty, **or non-workflow** (rows that parse as JSON but
-carry no `tasks` object — the signature of a mid-pull auth failure that wrote error bodies like
-`{"message":"Unauthorized"}` into the ndjson) exits 2 (go back to Step 1 — this means the pull failed
-auth, NOT that there is no IAG4 usage; a genuinely IAG4-free platform still has real workflows WITH
-tasks). **If the script exits non-zero, STOP — do not write a report and never report "0 workflows /
-0 IAG4 tasks" off a failed pull.** Fix auth (OAuth
-token → `Authorization: Bearer` header, not `?token=`), re-pull, and re-run. Then **read
-`tmp/analysis.json`** — it contains `identifiers`, `counts`, sorted `workflows[]`, sorted `forms[]`,
-and an aggregated `checklist`. Do not re-walk the workflows yourself; the JSON is authoritative for
-Steps 2–3 of the report.
+consumes `tmp/{wf_all.ndjson,adapters.json,apps.json,json-forms.json}` (plus, in `--local` mode, any
+`*.json` workflow/project-export files under `--local-dir`). A missing scope flag exits non-zero.
+
+**Exit codes / failure handling:**
+- In **live** mode, a `wf_all.ndjson` that is missing, empty, **or non-workflow** (rows that parse as
+  JSON but carry no `tasks` object — the signature of a mid-pull auth failure that wrote error bodies
+  like `{"message":"Unauthorized"}` into the ndjson) exits 2. This means the pull failed auth, NOT
+  that there is no IAG4 usage; a genuinely IAG4-free platform still has real workflows WITH tasks.
+  **If it exits non-zero, STOP — do not write a report and never report "0 workflows / 0 tasks" off a
+  failed pull.** Fix auth (OAuth token → `Authorization: Bearer` header, not `?token=`), re-pull, re-run.
+- In **`--local`** mode the script never hard-fails on missing data (that is the whole point — analyze
+  what's on disk). If there are no workflow docs to read, it emits an empty report and a `warnings[]`
+  entry; surface that warning to the user rather than pretending zero usage was confirmed.
+
+Then **read `tmp/analysis.json`** — it contains `identifiers` (now incl. `adapter_display_names`),
+`mode`, `counts`, sorted `workflows[]` (each with `interface`+`referenced_by` per task and a
+`called_by` list), sorted `forms[]`, `devices`, an aggregated `checklist`, `unresolved_children`, and
+`warnings`. Do not re-walk the workflows yourself; the JSON is authoritative for the report.
+
+**New fields (render these — do NOT recompute):**
+- **`interface`** (per Gateway4 task, req a) — `"AG Manager"` (AGManager application) or the ACTUAL
+  adapter name (verbatim). This tells the user which Gateway5 cluster the task must map to.
+- **`referenced_by`** (per Gateway4 task, req b) — other tasks in the SAME workflow that consume this
+  task's output (`$var.<taskId>.…` or a `{"task":"<taskId>"}` job ref). Render as "used by: …".
+- **`called_by`** (per workflow, req c) — the IN-SCOPE parent workflows that call this workflow via
+  childJob. Only in-scope parents ever appear (rule 3).
+- **`unresolved_children`** / **`warnings`** — referenced workflows that could not be read. Surface,
+  never fabricate their contents (rule 2).
 
 **What the script does (documented here so the report strings stay reviewable — the script is the
 source of truth; do NOT hand-classify):**
@@ -263,8 +356,20 @@ exactly one row, with the verbatim recommendation the report prints:
 | Detected IAG4 task | `iag4_type` label | Short recommendation (verbatim) |
 |---|---|---|
 | **Device/group self-management** (add/remove/create/delete device(s) or group) — checked first | `self-management` | move to the Inventory Manager application; drop this task |
-| Playbook/role op — name/summary/description contains "playbook" or "role" (e.g. `install_remove_inactive`, `transfer_image`) | `ansible-playbook` | register playbook as an IAG5 ansible-playbook service; call via GatewayManager.runService |
-| **Everything else** — any other IAG4 op (`itential_cli`, `isAlive`, `runCommand`, `getDeviceConfig`, …) | `python-script` | re-implement as an IAG5 python-script service; call via GatewayManager.runService |
+| Playbook/role op — name/summary/description contains "playbook" or "role" (e.g. `install_remove_inactive`, `transfer_image`) | `ansible-playbook` | register playbook as a Gateway5 ansible-playbook service; call via GatewayManager.runService |
+| **Everything else** — any other IAG4 op (`itential_cli`, `isAlive`, `runCommand`, `getDeviceConfig`, …) | `python-script` | re-implement as a Gateway5 python-script service; call via GatewayManager.runService |
+
+*Interface, references, closure (the script also computes these — render, don't recompute):*
+- **Interface (req a):** each Gateway4 task is tagged `interface` = `"AG Manager"` when it uses the
+  AGManager application, else the actual `automation_gateway` adapter name it carries — so the user
+  can map each task to the right Gateway5 cluster.
+- **Task output references (req b):** `referenced_by` lists other tasks in the same workflow that
+  consume the Gateway4 task's output (via `$var.<taskId>.` or a `{"task":"<taskId>"}` job ref).
+- **Workflow references (req c):** `called_by` lists the in-scope parent workflows that call the
+  workflow via childJob (`app == "WorkFlowEngine"`, `variables.incoming.workflow`).
+- **Scope closure (rule 3):** the scope flag is a SEED; the script follows childJob edges DOWN to the
+  transitive closure and analyzes only that set. Children it can't find in the pool land in
+  `unresolved_children` — the skill's Step-1 closure loop pulls them (live) or they become a warning.
 
 `python-script` is the default. The only questions this skill ever asks are the Step 0 pair
 (working dir + scope), an unclear `.env` purpose (Step 0), or **unresolved IAG4 identifiers**
@@ -305,9 +410,16 @@ the IAG5/replacement endpoint — returns no data once IAG4 is removed." (Refere
 JSON-form scanning is performed by the same script run in Step 2; its results are in
 `analysis.json → forms[]`. No separate action.
 
-## Step 4 — Scan IAG4 assets (local dir / IAG4 pull)
+## Step 4 — Scan Gateway4 assets (local directory or Gateway4 HTTP API)
 
-Only if IAG4 assets are in scope. Classify each file and attach the verbatim recommendation:
+Only if Gateway4 is in scope. Read the assets from whichever source the user has (Step 0):
+- **local directory** → read the files from disk; or
+- **Gateway4 HTTP API** → read-only GETs against Gateway4 using the username/password the user
+  provided (never a mutating call).
+
+Never use `iagctl` or any Gateway5 endpoint (out of scope). If the user has neither a local dir nor
+Gateway4 credentials, ask which they can provide; do not fabricate the asset list. Classify each
+file/asset and attach the verbatim recommendation:
 
 | Asset | Detection | `asset_type` | Short recommendation (verbatim) |
 |---|---|---|---|
@@ -331,11 +443,14 @@ source when IAG4 is removed. Read `analysis.json → devices`:
   device: `` `{device_name}` (origin {origins}) — device sourced from an IAG4 gateway adapter;
   re-home it in Inventory Manager before removing IAG4 ``.
 
-**(b) Gateway built-in inventory.** If IAG4 was not accessed, say so and note the action; if a
-built-in inventory is present, same action; if none, state that. Whenever inventory could exist,
-add the checklist item: move it into the **Inventory Manager** application in IAP; inventory
-variables can still be passed into IAG5 scripts/playbooks at run time via IAP workflows.
-(Lightweight this version — deeper Inventory Manager mapping guidance comes later.)
+**(b) Gateway4 built-in inventory.** Base this ONLY on the Gateway4 source the user gave (local dir
+or Gateway4 HTTP API GETs) — never on Gateway5. If Gateway4 was not in scope / no source provided,
+say so and note the action generically ("if the Gateway4 gateway holds a built-in inventory, move it
+to Inventory Manager"); if an inventory is present, same action; if there clearly is none, state
+that. Whenever inventory could exist, add the checklist item: move it into the
+**Inventory Manager** application in IAP; inventory variables can still be passed into Gateway5
+scripts/playbooks at run time via IAP workflows. (Lightweight this version — deeper Inventory
+Manager mapping guidance comes later.)
 
 ## Step 6 — Write the report
 
@@ -343,26 +458,59 @@ Fill `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-temp
 `<working-dir>/iag4-to-iag5-readiness.md` (the report is the **only** file in the working-dir
 root — all pulled JSON and scratch stay in `tmp/`).
 
-**Section order (fixed) + Table of Contents.** Render sections in this order: **Summary,
-Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure,
-Manual Action Checklist** — the checklist is **last**, after the repo section. Immediately under
-the header metadata, emit a `## Contents` table-of-contents with one linked entry per section
-(GitHub-style anchors, e.g. `[Scripts, Playbooks & Roles](#scripts-playbooks--roles)`) so the
-reader can jump around.
+**Analysis vs. recommendations — the split (important).** The **analysis** sections — Workflows,
+JSON Forms, Inventory — are **pure facts**: what is on the platform, nothing inferred, nothing
+recommended. NO per-task "what to do", NO remediation codes, NO legend. The only forward-looking /
+suggested content lives in the **two clearly-labelled sections at the end**: Recommended Repository
+Structure and Manual Action Checklist. Never put recommendation text into the analysis tables.
+
+**Section order (fixed) + Table of Contents.** Render sections in this order: **Summary, Workflows,
+JSON Forms, Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure, Manual Action
+Checklist** — the checklist is **last**, after the repo section. Immediately under the header table,
+emit a `## Contents` table-of-contents with one linked entry per section (GitHub-style anchors, e.g.
+`[Scripts, Playbooks & Roles](#scripts-playbooks--roles)`) so the reader can jump around.
+
+**WORDING — the rendered report must NOT contain "iag"/"IAG4"/"IAG5" (req d).** Use "Itential
+Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5". Keep literal API/app names
+(`GatewayManager.runService`, `AG Manager`) and the ACTUAL adapter names verbatim so the reader can
+identify them on the platform. When you fill the template: (1) substitute every `{{placeholder}}`,
+(2) **strip all `<!-- … -->` guidance comments** (they are for you, not the report), and (3) as a
+final self-check, confirm the written report contains no case-insensitive "iag" —
+`grep -i iag <working-dir>/iag4-to-iag5-readiness.md` must return nothing (the filename itself is not
+part of the file's content). If it matches, fix the wording before telling the user it's done.
 
 **Render the deterministic sections straight from `tmp/analysis.json`** — do not recompute:
-- Header identifiers ← `identifiers` (adapter type + instances + app); **Scope** line ← `scope`.
-  Summary counts ← `counts` (`n_workflows`, `n_iag4_tasks`, `n_forms`, `n_iag4_devices`).
-- **Workflows** section ← `workflows[]` (already sorted) as a **table, ONE ROW PER WORKFLOW**:
-  columns `Workflow | Workflow ID | Location | IAG4 Tasks & Recommendations`. Put ALL of a
-  workflow's IAG4 tasks in the last cell, one per line joined by literal `<br>`, each formatted
-  `` `task_id` **task_name** — short_recommendation ``. Do NOT emit one row per task — a single row
-  per workflow lets the reader see at a glance which workflows have more than one IAG4 task even
-  when names repeat. **Always print the `workflow_id`** — it disambiguates workflows that share a
-  name (the same use case cloned appears as several rows with identical names but distinct ids;
-  real distinct workflows, not a duplication artifact). Location cell is exactly `Global` when
-  `location_type == "global"`, else `«project_name» (project_id)`. **Never write "name
-  unavailable"** — a stale `@id:` prefix is Global, not a project.
+- **Header** = a two-column key/value table (Generated, Working directory, Mode ← `mode`, Platform
+  source, Gateway4 assets, Gateway4 matched ← `identifiers` (adapter type + instances; app label is
+  always `AG Manager`), Scope ← `scope`).
+- **Data-gap callout** — render a single `> **⚠ Data gap — N referenced child workflow(s) could not
+  be analyzed.**` line (N ← `unresolved_children` length) **only if** that list is non-empty; it
+  points the reader to the full list at the BOTTOM (Manual Action Checklist → General). Do NOT dump
+  the list up here. Any `warnings[]` entries not about unresolved children render as extra
+  `> **Warning:** …` lines. Never invent what a warned-about workflow contains (rule 2).
+- **Summary** counts ← `counts` (`n_workflows`, `n_gw4_tasks` ← `counts.n_iag4_tasks`, `n_forms`,
+  `n_gw4_devices` ← `counts.n_iag4_devices`), plus `n_unresolved` ← `unresolved_children` length.
+- **Workflows** section ← `workflow_groups[]` (already ordered) — **PURE FACTS, no
+  recommendations/codes**. **Grouped by location**: iterate `workflow_groups` (projects first by
+  name, then a final `Global` group; workflows within each already name-sorted). Do NOT re-sort.
+  - **Group headline** — `### {group.label}` where `label` is `«project_name» (project_id)` for a
+    project or `Global`. The project/Global identity lives HERE, so it is **not** repeated below
+    (no "Scope / Connector" column, no location in the detail heading — kills the repeated text).
+  - **Per-group index table** — one row per workflow in the group: `Workflow | Tasks | Interface(s) |
+    ID` = `` `workflow_name` | n_tasks | interfaces | `workflow_id` ``. `interfaces` ← the workflow's
+    `interfaces` array (distinct, task order) joined `, ` — factual `AG Manager` and/or actual adapter
+    name(s), for cluster mapping. **Always print `workflow_id`** — disambiguates same-named clones.
+  - **Detail section** (one per workflow in the group) — `#### \`workflow_name\` · \`workflow_id\``
+    (no location) then a **3-col** table, one row per task: `Task | Name | Interface` =
+    `` `task_id` | task_name | interface ``. `interface` (req a) is `AG Manager` or the actual adapter
+    name (verbatim). No recommendation column.
+  - **References** — collect the relationship lines in order: (1) if `called_by` (req c) non-empty,
+    `` Called by `name` (`id`), … `` (in-scope parents only); (2) for each task whose `referenced_by`
+    (req b) is non-empty, `` `task_id` output used by `id`, `id` ``. Zero lines → render nothing.
+    Exactly one line → inline `**References:** <line>`. More than one → `**References:**` then a
+    bullet per line. (This avoids the noise of a heading for a single fact.)
+  - `label` is built by the analyzer; **never write "name unavailable"** — a stale `@id:` prefix is
+    the `Global` group, not a project.
 - **JSON Forms** section ← `forms[]` (already sorted): `**form_name** — field_key
   (`bound_endpoint`): rebind…`. Forms are matched on the **binding endpoint only**; a
   `/configuration_manager/...` field that filters by `adapterType` is NOT flagged (see Step 2).
@@ -382,22 +530,29 @@ reader can jump around.
   into the report** — that pointer stays here in the skill: for how to write `services.yaml`, the
   `--property_name` named-arg contract, `repositories:` config, and `GatewayManager.runService`
   wiring, defer to `/iag`.
-- **Manual Action Checklist** — the **last** section — **grouped by item type**, each group under
-  its own `###` subheading, in fixed order: **Workflows** (← `checklist.workflows`, e.g.
-  `` `<key>` (<app>, <count> tasks) — <recommendation> ``), **JSON Forms** (← `checklist.forms`),
-  **Scripts, Playbooks & Roles** (← the Step 4 assets you classified), **Inventory** (← the
-  flagged devices from `analysis.json → devices` plus the gateway built-in-inventory action from
-  Step 5b), and **General** (cross-cutting items — MUST include a repo-setup item pointing at the
-  Recommended Repository Structure section ABOVE, e.g. `Set up the IAG5 service git repository —
-  see Recommended Repository Structure above (Option A recommended)`, plus a git-secret item).
-  **Render only groups that have items — drop an empty group entirely** (no empty heading).
-  `checklist.workflows`/`checklist.forms` are already aggregated by recommendation with counts.
+- **Manual Action Checklist** — the **last** section — **grouped by item type**, each group under its
+  own `###` subheading, in fixed order: **Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory,
+  General**. **Render only groups that have items — drop an empty group entirely.**
+  - **Workflows** ← `checklist.workflows` (already sorted by recommendation then name, so identical
+    recommendations cluster). Each item is **self-contained** — it carries its own recommendation
+    text, so no legend is needed: `` - [ ] `key` (app_display, N task/tasks) — recommendation ``. Use
+    `app_display` (already `AG Manager` or the adapter type) and pluralize `task`/`tasks` on `count`.
+    No codes, no divergence note.
+  - **JSON Forms** ← `checklist.forms`. **Scripts, Playbooks & Roles** ← the Step 4 assets.
+  - **Inventory** ← flagged devices from `analysis.json → devices` (one `- [ ]` per device) plus the
+    gateway built-in-inventory action (Step 5b); scoped/local run where devices weren't pulled →
+    "Skipped — outside scan scope."
+  - **General** ← cross-cutting items: a repo-setup item linking to the Recommended Repository
+    Structure section (`Set up the Gateway5 service git repository — see [Recommended Repository
+    Structure](#recommended-repository-structure) (Option A recommended)`) and a git-secret item.
+    **THEN, if `unresolved_children` is non-empty, render the moved data-gap list here** under a bold
+    label `**Unresolved child workflows — pull into scope (live) or add JSON to \`--local-dir\`, then
+    re-run:**` with one `- [ ]` per name. This is the single place the full list lives (the top
+    callout points here). Do NOT emit service counts.
 
-Then add the sections you produced yourself: **Scripts/Playbooks/Roles** (Step 4) and the
-gateway-inventory half of **Inventory** (Step 5b). The **device-origin** half of Inventory (5a)
-comes from `analysis.json → devices` — render each flagged device and add a `- [ ]` checklist item
-per flagged device (or one consolidated item if many). All sections go in the fixed template
-order; sections with no findings get `No IAG4 references found.`
+The **Inventory** report section (not the checklist) renders the device-origin finding as a lead line
++ a single dot-separated list of device names (not one bullet each — that's the checklist's job);
+sections with no findings get `No Gateway4 references found.`
 
 Finally, tell the user the report path and give a one-paragraph headline of the counts. Note
 that `tmp/` is read-cache/scratch and safe to delete.
@@ -406,31 +561,41 @@ that `tmp/` is read-cache/scratch and safe to delete.
 
 ## Gotchas
 
-- **Read-only, always.** Never mutate IAP or IAG. If a step would create/update/delete/import,
-  don't — write it into the report as a manual action instead.
-- **`AGManager` (IAG4) ≠ `GatewayManager` (IAG5).** Two different applications. Flag `AGManager`;
-  never flag `GatewayManager` — it is the IAG5 target interface.
+- **Read-only, always (rule 1).** Never mutate IAP or IAG. If a step would create/update/delete/
+  import, don't — write it into the report as a manual action instead.
+- **Never fabricate (rule 2).** If an identifier, classification, reference, adapter name, or
+  workflow's contents can't be read, STOP and ask the user. Unknowns surface as
+  `unresolved_children`/`warnings` — never a plausible guess.
+- **Respect scope (rule 3).** A scoped run analyzes ONLY the seed + its transitive childJob
+  closure. Never pull or report anything outside that set. `--all` is the ONLY whole-platform mode.
+- **Scoped pulls + local-only (rule 4).** Don't bulk-pull for a scoped run — pull the seed, then
+  follow references (closure loop). With no API, run `--local` against the working dir; unresolved
+  references become a last-resort warning.
+- **Report wording (req d).** The rendered report must contain no "iag"/"IAG4"/"IAG5" — use
+  "Gateway4"/"Gateway5". Keep `GatewayManager.runService`, `AG Manager`, and actual adapter names
+  verbatim. Strip template comments and `grep -i iag` the final report as a self-check.
+- **`AGManager` (Gateway4) ≠ `GatewayManager` (Gateway5).** Two different applications. Flag
+  `AGManager` (rendered as "AG Manager"); never flag `GatewayManager` — it is the Gateway5 target.
+- **Interface tag drives cluster mapping (req a).** Each Gateway4 task's `interface` is "AG Manager"
+  or the actual adapter name — this is what tells the user which Gateway5 cluster to map it to.
 - **Adapter type vs instance.** A task's `app` is the adapter *type*; the instance name lives
   elsewhere. Resolve via `apps.json`/`adapters.json`; recognize both so you don't miss tasks.
 - **OAuth token goes in the `Authorization: Bearer` header, NOT `?token=`.** `?token=` only
   works for local `/login` tokens. Sending an OAuth token as a query param returns "malformed
   token" — the #1 auth failure here.
-- **Paginate the workflows list.** It caps at 100 rows per page regardless of `limit`. Loop on
-  `total` (see Step 1) or you silently scan only the first 100 of possibly thousands.
-- **Both global and project workflows.** The `workflows` list returns global **and**
-  `@{projectId}:`-scoped workflows, so paginating it covers both. Only fall back to project
-  export for projects whose workflows are ACL-hidden from the list.
-- **Static dropdowns are not a concern.** Only `binding: true` REST-bound dropdowns can point at IAG4.
+- **`--all` paginates; scoped pulls don't.** The `workflows` list caps at 100/page — only the
+  `--all` bulk pull loops on `total`. Scoped runs pull via project export / by-name instead.
+- **Static dropdowns are not a concern.** Only `binding: true` REST-bound dropdowns can point at Gateway4.
 - **The script owns workflow + form classification — never hand-classify.** `analyze_iag4.py`
-  emits `python-script` as the default. Only *unresolved IAG4 identifiers* (empty `identifiers`
-  block — Step 1b), an *unclear `.env` purpose*, or the *Step 0 working-dir/scope pair* warrant a
-  question — never the per-task approach or the source.
+  emits `python-script` as the default and computes interface/refs/closure. Only *unresolved
+  identifiers* (empty `identifiers` block — Step 1b), an *unclear `.env` purpose*, or the *Step 0
+  working-dir/scope/source questions* warrant a question — never the per-task approach or the source.
 - **Keep the recommendation strings in sync.** They live once as constants in
   `helpers/iag-migration/analyze_iag4.py` and must match `readiness-report-template.md`
   verbatim. Change them in both places or determinism breaks.
-- **Ask working dir + scope first.** If not supplied, ask both up front (Step 0). Warn that
+- **Ask working dir + scope + data source first.** If not supplied, ask up front (Step 0). Warn that
   `--all` can overflow a small model's context on large platforms.
-- **Identification only.** Do not create IAG5 services, edit workflows, or rewrite scripts here.
+- **Identification only.** Do not create Gateway5 services, edit workflows, or rewrite scripts here.
   Route actual builds to `/iag`.
 
 ## See also

--- a/.claude/skills/iag4-to-iag5/SKILL.md
+++ b/.claude/skills/iag4-to-iag5/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: iag4-to-iag5
+description: Assess how ready an environment is to move from Itential Automation Gateway 4 (IAG4) to IAG5. Use for phrases like "am I ready to move to IAG5", "assess my IAG4 to IAG5 migration", "what do I need to change to switch off gateway 4", "scan my workflows for automation gateway usage", "which workflows use IAG4", "IAG4 readiness report", or "evaluate my gateway migration". This skill does NOT perform the migration — it analyzes IAP assets (workflows in and out of projects, JSON forms) and IAG4 assets (scripts, playbooks, roles, inventory), then writes a deterministic markdown guideline of the manual actions the user must take. It is strictly READ-ONLY against IAP and IAG — it never creates, updates, or deletes anything on the platform; its only write is the report in the working directory. For actually building IAG5 services, use /iag.
+argument-hint: "[working-directory]"
+---
+
+# IAG4 → IAG5 Readiness Assessment (iag4-to-iag5)
+
+**Path:** Standalone analysis — not part of the delivery lifecycle. Sibling to `/iag`.
+**Owns:** Identifying IAG4 usage across IAP + IAG4 assets and reporting the manual migration steps.
+**Produces:** `<working-dir>/iag4-to-iag5-readiness.md` — one deterministic markdown report. All
+pulled JSON, the auth cache, and scratch files go under `<working-dir>/tmp/` — never the
+working-dir root. Only the report lives in the root.
+
+## What this does (and does NOT do)
+
+IAG4 and IAG5 are architecturally different:
+
+| | IAG4 | IAG5 |
+|---|---|---|
+| IAP interface | `automation_gateway` adapter + **`AGManager`** application (`agmanager`) | **`GatewayManager`** application (`runService`) |
+| Runnable things | playbooks, scripts (any lang), roles, ansible modules | Python scripts, Ansible playbooks, OpenTofu plans, + `executable` type |
+| Source of services | uploaded to the gateway | **git repository only** |
+| Script inputs | positional args (`sys.argv[n]`, `./x a b`) | **named CLI flags** (`--from a --to b`) |
+| Inventory | built-in gateway inventory | **none** — use Inventory Manager in IAP |
+
+> **`AGManager` (IAG4) and `GatewayManager` (IAG5) are two different applications.** Flag
+> `AGManager`; never flag `GatewayManager` — it is the migration target.
+
+**This skill only IDENTIFIES and RECOMMENDS.** It does not rewrite scripts, generate IAG5
+service YAML, or rewire workflows — that is future work. Its single output is the readiness
+report. Keep every recommendation to a **manual action the user performs themselves**.
+
+### Read-only guarantee (hard rule)
+
+This skill is **read-only against IAP and IAG**. Its ONLY write target is the **working
+directory** (the report, plus any pulled read-cache JSON).
+- **Allowed:** auth (`/oauth/token`, `/login`), read/discovery **GET**s (workflows, json-forms,
+  projects export, apps, adapters), the POST-based **devices read** if needed; on IAG, only
+  read-only `iagctl get/describe/db export` or local files.
+- **Forbidden:** any create/update/delete/import/patch on IAP or IAG — no state-mutating
+  `POST/PUT/PATCH/DELETE`, no `iagctl db import`, no writing services, no editing/creating
+  workflows, forms, projects, inventory, or gateway config. If a step *would* mutate the
+  platform, **do not do it** — record it in the report as a manual action for the user.
+
+These two rules are agent guidance — they shape the recommendations but are **not** printed in
+the report (the report is a terse checklist, not a narrative):
+1. IAG5 runs **Python scripts, Ansible playbooks, OpenTofu plans** natively, plus an
+   **`executable`** type (`filename` + `arg-format`) for other binaries/scripts. Anything not
+   directly runnable needs a wrapper (usually a Python wrapper).
+2. IAG5 services run **only from a git repository** — migrated assets must live in a git repo the
+   gateway can reach (this is `/iag`'s `repositories:` block). The report includes a **Recommended
+   Repository Structure** section (Options A/B/C + naming conventions) that you tailor to the
+   environment's actual services — see Step 6. Defer to `/iag` for the mechanics of `services.yaml`,
+   named-arg contracts, and `runService` wiring.
+
+**Defer to `/iag` for all "how".** This skill identifies *what* must change; `/iag` is the
+authoritative reference for building the IAG5 service, the `--property_name` named-arg contract,
+`repositories:`, and `GatewayManager.runService` wiring (incl. `clusterId` via
+`GET /gateway_manager/v1/gateways/`). Do not duplicate that here — point the reader to `/iag`.
+
+## Determinism contract
+
+Same inputs ⇒ identical report. Enforce:
+- Fixed section set/order — from `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-template.md`. Never drop a section; empty sections render `No IAG4 references found.`
+- **The workflow + JSON-form findings are produced by `analyze_iag4.py`** (Step 2), not by the
+  model — that script owns their determinism (detection, classification, sorting, aggregation).
+  Its recommendation strings MUST stay byte-identical to the template. Render those sections
+  verbatim from `tmp/analysis.json`; only the scripts + inventory sections are model-authored.
+- Stable sort (the script already applies this): workflows by name (asc); tasks within a workflow
+  by task id (asc); forms by name (asc); IAG4 assets by filename (asc); checklist by section then name.
+- The **only** volatile line is the header `Generated:` date and the source lines. No per-row
+  timestamps, no random ordering, no rephrasing of the fixed recommendation strings below.
+- The report is a **terse checklist** — header, summary table, bullet/sub-bullet workflow list,
+  short form/asset/inventory sections, checklist. Do NOT print the read-only guarantee, the two
+  IAG5 rules, or any adapter/instance explainer in the report — those are agent guidance only.
+
+---
+
+## Step 0 — Working directory, scope & data sources
+
+**Ask these two up front if the user did not already supply them** (use AskUserQuestion):
+
+1. **Working directory** — where the report is written. If the user passed one as an argument,
+   use it; else ask.
+2. **Scan scope** — the workflow analysis (Step 2) is driven by one of three deterministic
+   scopes; ask which the user wants and carry it into the script flag:
+   - **project(s)** → `--projects <id,id>` (recommended — one or more project ids)
+   - **explicit workflow list** → `--workflows "Name A;Name B"`
+   - **all workflows** → `--all` — **not recommended**: on a large platform this scans every
+     workflow (here 1504) and can overflow a small model's context window. Only use if the user
+     explicitly asks.
+
+Then establish the data sources:
+
+3. **Never assume the source of assets.** Look for a `.env` in the working dir (the auth cache
+   lives at `tmp/.auth.json`).
+   - If a `.env` exists, determine whether it targets **IAP only, IAG only, or both**. If the
+     file's purpose is unclear, **ask the user** — do not guess.
+   - Ask (or confirm) what the user has: local IAP asset JSON, live IAP access, local IAG4
+     assets, live IAG4 access — any combination, including IAP-only or IAG4-only.
+4. Establish each source as `live`, `local`, or `none`. **Local files take precedence** over
+   live pulls when both exist. Record all of this for the report header.
+
+## Step 1 — IAP data (only if IAP is in scope)
+
+Prefer local files in the working dir. Otherwise pull live, reusing the `/explore` mechanics.
+**All pulled JSON and the auth cache go under `<working-dir>/tmp/`** — create it first
+(`mkdir -p <working-dir>/tmp`). Never write these to the working-dir root.
+
+**Auth.** Read `PLATFORM_URL`, `AUTH_METHOD`, and credentials from `<working-dir>/.env`. Reuse
+`tmp/.auth.json` if present; silent re-auth from `.env` on 401/403 (AGENTS.md auth-reuse
+procedure). Never ask for credentials if `.env` exists. **The token transport depends on the
+auth method — do not mix them up (this is the #1 cause of "malformed token" failures):**
+
+- **OAuth / cloud (`AUTH_METHOD=oauth`):** `POST /oauth/token`
+  (`Content-Type: application/x-www-form-urlencoded`, body
+  `grant_type=client_credentials&client_id=...&client_secret=...`) → `access_token`. Send it on
+  **every** call as an `Authorization: Bearer <token>` **header**. `?token=` does NOT work for
+  OAuth tokens.
+- **Local (`AUTH_METHOD=login` / username+password):** `POST /login` (`application/json`,
+  `{"username":...,"password":...}`) → token string. Send it as a `?token=<token>` **query
+  param**.
+
+**Pull** — read-only GETs only, saved into `tmp/` (validate each with `jq type`). OAuth example
+(reuse the `$AUTH` header var for every call — this is the pattern that actually works):
+```bash
+mkdir -p <working-dir>/tmp
+TOKEN=$(jq -r .access_token <working-dir>/tmp/.auth.json)
+AUTH="Authorization: Bearer ${TOKEN}"
+curl -s -H "$AUTH" "{BASE}/automation-studio/apps/list"   -o tmp/apps.json
+curl -s -H "$AUTH" "{BASE}/health/adapters"               -o tmp/adapters.json
+curl -s -H "$AUTH" "{BASE}/json-forms/forms"              -o tmp/json-forms.json
+```
+
+**Projects — optional, defensive fallback only.** Project names now come from each workflow's own
+`namespace` field (returned inline on the workflows list), so `projects.json` is **no longer the
+primary source** for the `project_id → name` map. The script uses it only as a fallback for the
+rare workflow that lacks a namespace but whose name prefix still resolves to a live project. Pull
+it if convenient (paginate the same 100/page cap; merge every page's `data[]` into one
+`{"data":[...]}`), but a missing/partial `projects.json` no longer causes `name unavailable`:
+```bash
+total=$(curl -s -H "$AUTH" "{BASE}/automation-studio/projects?limit=1" | jq '.metadata.total')
+skip=0; echo '{"data":[]}' > tmp/projects.json
+while [ "$skip" -lt "${total:-0}" ]; do
+  curl -s -H "$AUTH" "{BASE}/automation-studio/projects?limit=100&skip=${skip}" \
+    | jq '{data:.data}' > tmp/projects.page.json
+  jq -s '{data: (.[0].data + .[1].data)}' tmp/projects.json tmp/projects.page.json > tmp/projects.merged.json \
+    && mv tmp/projects.merged.json tmp/projects.json
+  skip=$((skip+100))
+done
+rm -f tmp/projects.page.json
+```
+A workflow is treated as project-owned **only** when its `namespace` says so; a workflow whose name
+carries a stale `@{id}:` prefix for a deleted project is reported as **Global**, not `name
+unavailable`.
+
+**Devices — for the Inventory check (read-only, POST is a query not a mutation).** So the analyzer
+can tell whether Configuration Manager devices are sourced from an IAG4 gateway adapter, pull the
+device list into `tmp/devices.json`. `POST /configuration_manager/devices` is the "Find Devices"
+read query; body `{"options":{"start":0,"limit":100}}`, response shape `{total, list:[...]}` where
+each device carries `origins[]` (the source adapter instances). Paginate on `total`:
+```bash
+total=$(curl -s -H "$AUTH" -H "Content-Type: application/json" \
+  "{BASE}/configuration_manager/devices" -d '{"options":{"start":0,"limit":1}}' | jq .total)
+start=0; echo '{"list":[]}' > tmp/devices.json
+while [ "$start" -lt "${total:-0}" ]; do
+  curl -s -H "$AUTH" -H "Content-Type: application/json" \
+    "{BASE}/configuration_manager/devices" -d "{\"options\":{\"start\":${start},\"limit\":100}}" \
+    | jq '{list:.list}' > tmp/devices.page.json
+  jq -s '{list: (.[0].list + .[1].list)}' tmp/devices.json tmp/devices.page.json > tmp/devices.merged.json \
+    && mv tmp/devices.merged.json tmp/devices.json
+  start=$((start+100))
+done
+rm -f tmp/devices.page.json
+```
+Skip this only if IAP is out of scope or Configuration Manager is not installed. If `devices.json`
+is absent the analyzer degrades gracefully (reports "device origins not checked").
+
+**Workflows — MUST paginate (the list caps at 100 per page).** A single `?limit=500` silently
+returns only 100 rows while `total` may be far higher (e.g. 1504) — you WILL miss workflows.
+Read `total` from the first page, then loop `skip` in steps of the returned page size, appending
+each page's `items[]`:
+```bash
+total=$(curl -s -H "$AUTH" "{BASE}/automation-studio/workflows?limit=1" | jq .total)
+# FAIL FAST: if `total` is not a number, auth failed (the first call returned an error body, not a
+# workflows page). Do NOT proceed — an empty pull produces a misleading all-zeros report. The #1
+# cause is sending an OAuth token as ?token= instead of the Authorization: Bearer header.
+case "$total" in ''|*[!0-9]*) echo "AUTH/PULL FAILED — workflows 'total' is not numeric ('$total'). Fix auth (OAuth token goes in the Authorization: Bearer HEADER, not ?token=) and re-run." >&2; exit 1;; esac
+skip=0; : > tmp/wf_all.ndjson
+while [ "$skip" -lt "$total" ]; do
+  curl -s -H "$AUTH" "{BASE}/automation-studio/workflows?limit=100&skip=${skip}" \
+    | jq -c '.items[]' >> tmp/wf_all.ndjson
+  skip=$((skip+100))
+done
+# VALIDATE the pull before running the analyzer: the ndjson line count must match `total`. A count of
+# 0 (or well below `total`) means pages 401'd silently — re-auth and re-pull; never analyze a short pull.
+lines=$(wc -l < tmp/wf_all.ndjson)
+[ "$lines" -eq "$total" ] || echo "WARNING: pulled $lines of $total workflows — pull is incomplete (likely mid-run token expiry); re-auth and re-run before analyzing." >&2
+```
+`tmp/wf_all.ndjson` (one workflow doc per line) is the full set — global **and** `@{projectId}:`
+scoped workflows both come back from this list, so scanning it covers both. (If any project's
+workflows are ACL-hidden from the list, export that project via
+`GET /automation-studio/projects/{id}/export` and read `components[]` where
+`type == "workflow"` → `document.tasks`.)
+
+## Step 1b — Resolve the IAG4 identifiers
+
+IAG4 is matched two ways (confirmed):
+1. **`automation_gateway` adapter** — resolve the adapter **type** name (e.g. `AutomationGateway*`)
+   from `apps.json` / `adapters.json`, NOT the instance name. A task's `app` field carries the
+   adapter *type* (AGENTS.md rules 3 & 23). Note both the type and any instance names so you can
+   recognize either.
+2. **`AGManager` application** (the `agmanager` app) — workflow tasks with `task.app == "AGManager"`
+   (e.g. `itential_cli`, `itential_set_config`, and IAG4 device/group management operations).
+
+**`AGManager` (IAG4) ≠ `GatewayManager` (IAG5) — they are two different applications.** Flag
+`AGManager`. **Do NOT match `GatewayManager`** — that is the IAG5 target.
+
+**The analysis script (Step 2) resolves these identifiers itself** from `tmp/adapters.json`
+(instances whose `package_id` contains `automation_gateway`) and the fixed `AGManager` app name,
+and echoes them in `analysis.json → identifiers`. You only need to intervene if that block comes
+back empty/ambiguous (no apps.json, multiple gateway-like adapters) — then **stop and ask the
+user to confirm the exact identifiers** before continuing.
+
+---
+
+## Step 2 — Scan IAP workflows + JSON forms (deterministic script)
+
+The workflow and JSON-form analysis is done by a **deterministic script**, not by hand — this is
+what guarantees the same inputs always produce the same findings, and it keeps 1000s of workflow
+docs out of your context. Run it against the `tmp/` you populated in Step 1, passing the scope
+chosen in Step 0:
+
+```bash
+python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py \
+  --tmp <working-dir>/tmp \
+  { --projects <id,id>  |  --workflows "Name A;Name B"  |  --all }
+# writes <working-dir>/tmp/analysis.json
+```
+
+The script is **read-only** (its only write is `tmp/analysis.json`), needs no network/auth, and
+consumes `tmp/{wf_all.ndjson,adapters.json,apps.json,json-forms.json}`. A missing scope flag exits
+non-zero; a `wf_all.ndjson` that is missing, empty, **or non-workflow** (rows that parse as JSON but
+carry no `tasks` object — the signature of a mid-pull auth failure that wrote error bodies like
+`{"message":"Unauthorized"}` into the ndjson) exits 2 (go back to Step 1 — this means the pull failed
+auth, NOT that there is no IAG4 usage; a genuinely IAG4-free platform still has real workflows WITH
+tasks). **If the script exits non-zero, STOP — do not write a report and never report "0 workflows /
+0 IAG4 tasks" off a failed pull.** Fix auth (OAuth
+token → `Authorization: Bearer` header, not `?token=`), re-pull, and re-run. Then **read
+`tmp/analysis.json`** — it contains `identifiers`, `counts`, sorted `workflows[]`, sorted `forms[]`,
+and an aggregated `checklist`. Do not re-walk the workflows yourself; the JSON is authoritative for
+Steps 2–3 of the report.
+
+**What the script does (documented here so the report strings stay reviewable — the script is the
+source of truth; do NOT hand-classify):**
+
+*Workflows.* A task is an **IAG4 task** if its `app`/`location` matches the automation_gateway
+adapter (type `AutomationGateway`, or a resolved instance id) or the `AGManager` app. It **never**
+flags `GatewayManager` (IAG5). Each IAG4 task is classified from its name/summary/description into
+exactly one row, with the verbatim recommendation the report prints:
+
+| Detected IAG4 task | `iag4_type` label | Short recommendation (verbatim) |
+|---|---|---|
+| **Device/group self-management** (add/remove/create/delete device(s) or group) — checked first | `self-management` | move to the Inventory Manager application; drop this task |
+| Playbook/role op — name/summary/description contains "playbook" or "role" (e.g. `install_remove_inactive`, `transfer_image`) | `ansible-playbook` | register playbook as an IAG5 ansible-playbook service; call via GatewayManager.runService |
+| **Everything else** — any other IAG4 op (`itential_cli`, `isAlive`, `runCommand`, `getDeviceConfig`, …) | `python-script` | re-implement as an IAG5 python-script service; call via GatewayManager.runService |
+
+`python-script` is the default. The only questions this skill ever asks are the Step 0 pair
+(working dir + scope), an unclear `.env` purpose (Step 0), or **unresolved IAG4 identifiers**
+(empty/ambiguous `identifiers` block — Step 1b). Never ask how to classify a task.
+
+**Project name — from the workflow's `namespace`, not the name prefix.** Project membership is
+resolved from each workflow's authoritative `namespace` field (`{type:"project", _id, name}`), NOT
+by parsing the `@<id>:` name prefix. A workflow is **in a project** (and the report shows the
+project name) iff `namespace` marks it project-owned; otherwise it is **Global** — including
+workflows whose name still carries a stale `@<id>:` prefix pointing at a deleted project (a bulk-
+import leftover, not live membership). Each entry carries `location_type` (`global`/`project`),
+`project_id`, `project_name`. Render location as `«name» (id)` for a project, else `Global`.
+**Never emit "name unavailable"** — the old projects.json-prefix lookup produced that; `namespace`
+does not. (`projects.json` is now only a defensive fallback for the rare workflow missing a
+namespace whose prefix still resolves to a live project.) Also note `workflow_id` — it
+disambiguates copies that share a name.
+
+**Task ids repeat across workflow copies — that is correct, not a bug.** The same use case is
+often cloned into many projects, so each copy legitimately shares the same internal task id (e.g.
+`49eb`). The id is the real key from the workflow's `tasks` map; distinct copies are distinct
+`workflow_id`s. Do not "fix" or dedupe them.
+
+*JSON forms.* A form field is IAG4-bound only when its **binding endpoint URL** points at the IAG4
+automation_gateway adapter route prefix (`automationgateway` / `automation_gateway`) or the
+`agmanager` app — dropdowns and any other REST-bound field alike. The script matches on the
+**endpoint path only**: `base`+`href`, `originalHref`, `links[].href`, and the `binding:hyperSchema`
+mirror in `bindingSchema.properties`. **It deliberately does NOT scan the request body.** A field
+bound to `/configuration_manager/...` that merely *filters* by
+`options.adapterType: ["AutomationGateway"]` is a **Configuration Manager** field, **not** an
+IAG4-bound field — flagging it is a false positive (Config Manager is not IAG4; the device-origin
+check in Step 5 is what covers IAG4-sourced devices). Each real hit lands in `forms[]` as
+`{form_name, field_key, bound_endpoint, matched_on}`; the report prints the fixed line "rebind to
+the IAG5/replacement endpoint — returns no data once IAG4 is removed." (Reference shape:
+`${CLAUDE_PLUGIN_ROOT}/../../../helpers/assets/json-form-example-rest-bound.json` and `itential-json-forms`.)
+
+## Step 3 — (folded into Step 2)
+
+JSON-form scanning is performed by the same script run in Step 2; its results are in
+`analysis.json → forms[]`. No separate action.
+
+## Step 4 — Scan IAG4 assets (local dir / IAG4 pull)
+
+Only if IAG4 assets are in scope. Classify each file and attach the verbatim recommendation:
+
+| Asset | Detection | `asset_type` | Short recommendation (verbatim) |
+|---|---|---|---|
+| Python script with positional args | `.py` reading `sys.argv[n]` / no argparse named flags | `python` | convert positional args to argparse flags; place in a git repo |
+| Python script already using named flags | `.py` with argparse named flags | `python` | already uses named args; place in a git repo |
+| Bash/shell/other script | `.sh`/`.bash`/other executable script | `shell` | wrap in a Python script (python-script service) or register as an executable service; place in a git repo |
+| Ansible role | role dir layout (`tasks/main.yml`, etc.) | `role` | wrap in a playbook or Python script; place in a git repo |
+| Ansible playbook | `.yml`/`.yaml` playbook (plays/tasks, not a role) | `playbook` | place in a git repo; no code change |
+
+## Step 5 — IAG4 inventory
+
+IAG4's built-in inventory does not exist in IAG5. This section has **two parts**:
+
+**(a) Configuration Manager device origins — from the script.** The analyzer reads
+`tmp/devices.json` (pulled in Step 1) and flags any device whose `origins[]` (the source
+adapter/broker) is one of the resolved IAG4 gateway adapter instances — those devices lose their
+source when IAG4 is removed. Read `analysis.json → devices`:
+- `present: false` → devices weren't pulled: "Config Manager devices not pulled — cannot check device origins."
+- `present: true, n_iag4 == 0` → "No Config Manager devices are sourced from an IAG4 gateway."
+- `present: true, n_iag4 > 0` → state the count of `n_iag4`/`n_devices` and list each flagged
+  device: `` `{device_name}` (origin {origins}) — device sourced from an IAG4 gateway adapter;
+  re-home it in Inventory Manager before removing IAG4 ``.
+
+**(b) Gateway built-in inventory.** If IAG4 was not accessed, say so and note the action; if a
+built-in inventory is present, same action; if none, state that. Whenever inventory could exist,
+add the checklist item: move it into the **Inventory Manager** application in IAP; inventory
+variables can still be passed into IAG5 scripts/playbooks at run time via IAP workflows.
+(Lightweight this version — deeper Inventory Manager mapping guidance comes later.)
+
+## Step 6 — Write the report
+
+Fill `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-template.md` and write
+`<working-dir>/iag4-to-iag5-readiness.md` (the report is the **only** file in the working-dir
+root — all pulled JSON and scratch stay in `tmp/`).
+
+**Section order (fixed) + Table of Contents.** Render sections in this order: **Summary,
+Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure,
+Manual Action Checklist** — the checklist is **last**, after the repo section. Immediately under
+the header metadata, emit a `## Contents` table-of-contents with one linked entry per section
+(GitHub-style anchors, e.g. `[Scripts, Playbooks & Roles](#scripts-playbooks--roles)`) so the
+reader can jump around.
+
+**Render the deterministic sections straight from `tmp/analysis.json`** — do not recompute:
+- Header identifiers ← `identifiers` (adapter type + instances + app); **Scope** line ← `scope`.
+  Summary counts ← `counts` (`n_workflows`, `n_iag4_tasks`, `n_forms`, `n_iag4_devices`).
+- **Workflows** section ← `workflows[]` (already sorted) as a **table, ONE ROW PER WORKFLOW**:
+  columns `Workflow | Workflow ID | Location | IAG4 Tasks & Recommendations`. Put ALL of a
+  workflow's IAG4 tasks in the last cell, one per line joined by literal `<br>`, each formatted
+  `` `task_id` **task_name** — short_recommendation ``. Do NOT emit one row per task — a single row
+  per workflow lets the reader see at a glance which workflows have more than one IAG4 task even
+  when names repeat. **Always print the `workflow_id`** — it disambiguates workflows that share a
+  name (the same use case cloned appears as several rows with identical names but distinct ids;
+  real distinct workflows, not a duplication artifact). Location cell is exactly `Global` when
+  `location_type == "global"`, else `«project_name» (project_id)`. **Never write "name
+  unavailable"** — a stale `@id:` prefix is Global, not a project.
+- **JSON Forms** section ← `forms[]` (already sorted): `**form_name** — field_key
+  (`bound_endpoint`): rebind…`. Forms are matched on the **binding endpoint only**; a
+  `/configuration_manager/...` field that filters by `adapterType` is NOT flagged (see Step 2).
+- **Recommended Repository Structure** section (comes BEFORE the checklist) — tailor the
+  template's fixed Options A/B/C + Naming Conventions to THIS environment's migrated services (the
+  distinct `checklist.workflows` keys **plus** the Step 4 assets). **Option A (mono-repo) is ALWAYS
+  the recommendation** — do not make it conditional on service count, and do not print any service
+  counts anywhere in this section (no "small team / < 20 services" qualifiers on the option
+  headings either). In the Option A tree, emit one leaf per service foldered by domain, each
+  annotated `← was <original> (<iag4_type>)`; python-script leaves get `main.py` +
+  `requirements.txt`, ansible-playbook leaves get `playbook.yml`. Fill the Naming Conventions
+  "Examples" column with the actual service names mapped to `{team}-{domain}-{action}`. **Use
+  placeholder team names `team1`, `team2`, … (one team per domain in B/C) — never assume real team
+  names.** Domains are still derived from the services. Keep the option headings verbatim: `Option
+  A — Mono-repo (recommended)`, `Option B — Multi-repo (per-domain ownership)`, `Option C —
+  Service-file repo + code repos (separation of concerns)`. **Do NOT render a "See `/iag` …" line
+  into the report** — that pointer stays here in the skill: for how to write `services.yaml`, the
+  `--property_name` named-arg contract, `repositories:` config, and `GatewayManager.runService`
+  wiring, defer to `/iag`.
+- **Manual Action Checklist** — the **last** section — **grouped by item type**, each group under
+  its own `###` subheading, in fixed order: **Workflows** (← `checklist.workflows`, e.g.
+  `` `<key>` (<app>, <count> tasks) — <recommendation> ``), **JSON Forms** (← `checklist.forms`),
+  **Scripts, Playbooks & Roles** (← the Step 4 assets you classified), **Inventory** (← the
+  flagged devices from `analysis.json → devices` plus the gateway built-in-inventory action from
+  Step 5b), and **General** (cross-cutting items — MUST include a repo-setup item pointing at the
+  Recommended Repository Structure section ABOVE, e.g. `Set up the IAG5 service git repository —
+  see Recommended Repository Structure above (Option A recommended)`, plus a git-secret item).
+  **Render only groups that have items — drop an empty group entirely** (no empty heading).
+  `checklist.workflows`/`checklist.forms` are already aggregated by recommendation with counts.
+
+Then add the sections you produced yourself: **Scripts/Playbooks/Roles** (Step 4) and the
+gateway-inventory half of **Inventory** (Step 5b). The **device-origin** half of Inventory (5a)
+comes from `analysis.json → devices` — render each flagged device and add a `- [ ]` checklist item
+per flagged device (or one consolidated item if many). All sections go in the fixed template
+order; sections with no findings get `No IAG4 references found.`
+
+Finally, tell the user the report path and give a one-paragraph headline of the counts. Note
+that `tmp/` is read-cache/scratch and safe to delete.
+
+---
+
+## Gotchas
+
+- **Read-only, always.** Never mutate IAP or IAG. If a step would create/update/delete/import,
+  don't — write it into the report as a manual action instead.
+- **`AGManager` (IAG4) ≠ `GatewayManager` (IAG5).** Two different applications. Flag `AGManager`;
+  never flag `GatewayManager` — it is the IAG5 target interface.
+- **Adapter type vs instance.** A task's `app` is the adapter *type*; the instance name lives
+  elsewhere. Resolve via `apps.json`/`adapters.json`; recognize both so you don't miss tasks.
+- **OAuth token goes in the `Authorization: Bearer` header, NOT `?token=`.** `?token=` only
+  works for local `/login` tokens. Sending an OAuth token as a query param returns "malformed
+  token" — the #1 auth failure here.
+- **Paginate the workflows list.** It caps at 100 rows per page regardless of `limit`. Loop on
+  `total` (see Step 1) or you silently scan only the first 100 of possibly thousands.
+- **Both global and project workflows.** The `workflows` list returns global **and**
+  `@{projectId}:`-scoped workflows, so paginating it covers both. Only fall back to project
+  export for projects whose workflows are ACL-hidden from the list.
+- **Static dropdowns are not a concern.** Only `binding: true` REST-bound dropdowns can point at IAG4.
+- **The script owns workflow + form classification — never hand-classify.** `analyze_iag4.py`
+  emits `python-script` as the default. Only *unresolved IAG4 identifiers* (empty `identifiers`
+  block — Step 1b), an *unclear `.env` purpose*, or the *Step 0 working-dir/scope pair* warrant a
+  question — never the per-task approach or the source.
+- **Keep the recommendation strings in sync.** They live once as constants in
+  `helpers/iag-migration/analyze_iag4.py` and must match `readiness-report-template.md`
+  verbatim. Change them in both places or determinism breaks.
+- **Ask working dir + scope first.** If not supplied, ask both up front (Step 0). Warn that
+  `--all` can overflow a small model's context on large platforms.
+- **Identification only.** Do not create IAG5 services, edit workflows, or rewrite scripts here.
+  Route actual builds to `/iag`.
+
+## See also
+- `/iag` — building IAG5 services (Python/Ansible/OpenTofu), service YAML, `runService` wiring.
+- `/itential-inventory` — Inventory Manager, the IAG5 replacement for gateway inventory.
+- `/itential-json-forms` — REST-bound dropdown structure and `bindingSchema`.
+- `/explore` — auth + IAP pull mechanics reused in Step 1.
+- Analysis script: `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py` (Step 2, deterministic).
+- Template: `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-template.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Each skill owns a domain. **Invoke the skill using the Skill tool before working
 | `/builder-agent` | **Builder Agent** | Build all assets, test each component individually. Runs after Design. |
 | `/qa-agent` | **QA Agent** | Acceptance testing against the approved acceptance criteria + as-built record. Runs after Build — last technical stage before customer sign-off. |
 | `/iag` | — | Automation Gateway: IAG services (Python, Ansible, OpenTofu). |
+| `/iag4-to-iag5` | — | Assess IAG4→IAG5 migration readiness; identify IAG4 usage and produce a manual-action guideline. Analysis only, no migration. |
 | `/flowagent` | — | AI Agents: configure LLM providers, tools, and agent sessions. |
 | `/itential-mop` | — | Command templates with validation rules. |
 | `/itential-devices` | — | Devices, backups, diffs, device groups. |

--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ Spec-driven infrastructure automation and orchestration — delivered by AI agen
 
 ## Table of Contents
 
-- [Prerequisites](#prerequisites)
-- [Getting Started](#getting-started)
-- [How to Use It](#how-to-use-it)
-- [Skills](#skills)
-- [Spec Library](#spec-library)
-- [Demo Specs](#demo-specs)
-- [Docs](#docs)
-- [Contributing](#contributing)
-- [Support](#support)
+- [Itential — Agentic Builder Skills](#itential--agentic-builder-skills)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Getting Started](#getting-started)
+  - [How to Use It](#how-to-use-it)
+  - [Skills](#skills)
+  - [Spec Library](#spec-library)
+  - [Demo Specs](#demo-specs)
+  - [Docs](#docs)
+  - [Contributing](#contributing)
+  - [Support](#support)
+  - [License](#license)
 
 ---
 
@@ -118,6 +121,9 @@ See [`docs/quickstart.md`](docs/quickstart.md) for the full setup and first deli
 "I want to explore what's available on my platform"
 → /itential-builder:explore
 
+"Am I ready to move from IAG4 to IAG5?"
+→ /itential-builder:iag4-to-iag5
+
 "Help me build a golden config for my devices and run compliance"
 → /itential-builder:itential-golden-config
 ```
@@ -145,6 +151,7 @@ See [`docs/quickstart.md`](docs/quickstart.md) for the full setup and first deli
 |-------|-------------|
 | `/itential-builder:flowagent` | Creates and runs AI agents on the Itential Platform. Configures LLM providers, registers tools (adapters, workflows, IAG services), and runs agent sessions. Use when building or operating Flow AI agents. |
 | `/itential-builder:iag` | Builds and runs IAG 5 services — Python scripts, Ansible playbooks, OpenTofu plans. Manages YAML service definitions, imports via `iagctl`, and calls services from Itential workflows via GatewayManager. |
+| `/itential-builder:iag4-to-iag5` | Assesses readiness to migrate from IAG4 to IAG5. Scans workflows, JSON forms, scripts, playbooks, and inventory for IAG4 usage (`AGManager` / `automation_gateway`). Produces a deterministic markdown readiness report with a manual-action checklist. Read-only — never modifies the platform. For building IAG5 services after the assessment, use `/iag`. |
 | `/itential-builder:itential-mop` | Builds Method of Procedure command templates with variable substitution and validation rules. Runs CLI pre-checks and post-checks against devices, and uses analytic templates for before/after config comparison. |
 | `/itential-builder:itential-devices` | Manages network devices in Itential Configuration Manager — onboard devices, take config backups, diff configurations, organize device groups, and apply device templates. |
 | `/itential-builder:itential-golden-config` | Builds golden config trees and node-level config specs that define the expected configuration standard for your devices. Runs compliance plans, grades results, and generates remediation configs for violations. |

--- a/helpers/iag-migration/analyze_iag4.py
+++ b/helpers/iag-migration/analyze_iag4.py
@@ -31,9 +31,22 @@ sys.dont_write_bytecode = True
 # NOTE: these strings are rendered into the markdown report, which must NOT contain "iag"/"IAG4"/
 # "IAG5" — use "Gateway4"/"Gateway5" instead. Literal API/app names (GatewayManager.runService,
 # AG Manager) and actual adapter names stay verbatim so the reader can identify them on the platform.
-REC_ANSIBLE = "register playbook as a Gateway5 ansible-playbook service; call via GatewayManager.runService"
-REC_PYTHON = "re-implement as a Gateway5 python-script service; call via GatewayManager.runService"
-REC_SELFMGMT = "move to the Inventory Manager application; drop this task"
+# Each Gateway4 workflow task gets ONE short CODE + a recommendation. The codes are defined once in
+# the report's "Recommended Actions" legend; task tables show only the code. Codes/recs are a
+# best-effort classification from the task's name/summary/description — the legend says "review each".
+REC_WRAP = "wrap in a Python script (preferred) or an Ansible playbook; run as a Gateway5 service"
+REC_REVIEW = "likely no code change — review how inventory is handled (Gateway5 has no built-in inventory)"
+REC_ARGS = "change positional args to named args (--flag / argparse); run as a Gateway5 python-script service"
+REC_INV = "move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation"
+# code + recommendation by classification type (1:1); CODE_ORDER is the legend / grouping order.
+CODE_BY_TYPE = {
+    "collection-or-role": "WRAP",
+    "ansible-playbook": "REVIEW",
+    "python-script": "ARGS",
+    "self-management": "INV",
+}
+REC_BY_CODE = {"WRAP": REC_WRAP, "REVIEW": REC_REVIEW, "ARGS": REC_ARGS, "INV": REC_INV}
+CODE_ORDER = ["WRAP", "REVIEW", "ARGS", "INV"]
 REC_FORM = "rebind to the Gateway5/replacement endpoint — returns no data once Gateway4 is removed."
 REC_DEVICE = "device sourced from a Gateway4 adapter; re-home it in Inventory Manager before removing Gateway4"
 
@@ -51,7 +64,12 @@ _SELFMGMT_RE = re.compile(
     r"\b(device|group)[_\s-]*(add|create|remove|delete|update|management)\b",
     re.IGNORECASE,
 )
-_PLAYBOOK_RE = re.compile(r"\b(playbook|role)\b", re.IGNORECASE)
+_PLAYBOOK_RE = re.compile(r"\bplaybook\b", re.IGNORECASE)
+_ROLE_RE = re.compile(r"\b(role|collection)\b", re.IGNORECASE)
+# ansible collection module name in a task's `name` field, e.g. cisco.ios_ios_command,
+# arista.eos_eos_ospf_interfaces — a letter-led token, a dot, then a module token. (A leading digit,
+# e.g. "33.j2", is NOT matched, so jinja/template names don't get misread as collection modules.)
+_FQCN_RE = re.compile(r"^[a-z][a-z0-9]*\.[a-z][a-z0-9_]*")
 # form endpoint tokens that indicate an IAG4 binding
 _FORM_IAG4_TOKENS = ("automationgateway", "automation_gateway", "automation-gateway", "agmanager")
 
@@ -123,13 +141,25 @@ def is_iag4_task(task, instance_ids, prefixes):
 
 
 def classify(task):
-    """Return (iag4_type, short_recommendation) for an IAG4 task."""
+    """Return (iag4_type, code, short_recommendation) for an IAG4 task — a best-effort classification
+    from the task's name/summary/description (the report legend says "review each"). Order matters:
+      1. device/group op on the Gateway4 adapter        -> self-management / INV
+      2. ansible playbook                                -> ansible-playbook / REVIEW
+      3. ansible collection-module task or role          -> collection-or-role / WRAP
+      4. everything else (treated as a python script)    -> python-script / ARGS
+    """
     hay = " ".join(str(task.get(k) or "") for k in ("name", "summary", "description", "canvasName"))
+    name = task.get("name") or ""
     if _SELFMGMT_RE.search(hay):
-        return "self-management", REC_SELFMGMT
-    if _PLAYBOOK_RE.search(hay):
-        return "ansible-playbook", REC_ANSIBLE
-    return "python-script", REC_PYTHON
+        t = "self-management"
+    elif _PLAYBOOK_RE.search(hay):
+        t = "ansible-playbook"
+    elif _ROLE_RE.search(hay) or _FQCN_RE.search(name):
+        t = "collection-or-role"
+    else:
+        t = "python-script"
+    code = CODE_BY_TYPE[t]
+    return t, code, REC_BY_CODE[code]
 
 
 def task_interface(task):
@@ -307,7 +337,7 @@ def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
                 continue
             if not is_iag4_task(t, instance_ids, prefixes):
                 continue
-            iag4_type, rec = classify(t)
+            iag4_type, code, rec = classify(t)
             iface = task_interface(t)
             if iface != "AG Manager":
                 adapter_names.add(iface)
@@ -317,8 +347,9 @@ def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
                 "app": t.get("app"),
                 "summary": t.get("summary"),
                 "interface": iface,                       # req (a): "AG Manager" or actual adapter name
-                "iag4_type": iag4_type,               # internal: used ONLY by the end Repo-Structure section
-                "short_recommendation": rec,          # internal: used ONLY by the end checklist, never the analysis
+                "iag4_type": iag4_type,               # internal: also drives the Repo-Structure section
+                "code": code,                             # short remediation code (WRAP/REVIEW/ARGS/INV)
+                "short_recommendation": rec,              # full text — used by the legend + checklist
                 "referenced_by": find_referrers(tasks, tid),  # req (b)
             })
         if hits:
@@ -328,6 +359,8 @@ def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
             for h in hits:
                 if h["interface"] not in interfaces:
                     interfaces.append(h["interface"])
+            # distinct recommendation codes for this workflow, in CODE_ORDER (for the group index)
+            codes = [c for c in CODE_ORDER if any(h["code"] == c for h in hits)]
             called_by = [
                 {"workflow_name": pool[p]["display"], "workflow_id": pool[p]["workflow_id"]}
                 for p in callers.get(i, [])
@@ -340,6 +373,7 @@ def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
                 "project_id": w["project_id"],
                 "project_name": w["project_name"],
                 "interfaces": interfaces,                 # req (a): distinct interfaces (AG Manager / adapter names)
+                "codes": codes,                           # distinct recommendation codes (CODE_ORDER)
                 "called_by": called_by,                   # req (c)
                 "tasks": hits,
             })
@@ -485,7 +519,7 @@ def build_checklist(workflows, forms):
     agg = {}
     for w in workflows:
         for t in w["tasks"]:
-            key = (t["task_name"], t["app"], t["short_recommendation"])
+            key = (t["task_name"], t["app"], t["code"], t["short_recommendation"])
             agg[key] = agg.get(key, 0) + 1
     wf_items = [
         {
@@ -493,12 +527,14 @@ def build_checklist(workflows, forms):
             "app": k[1],
             # display app: AGManager -> "AG Manager" (matches the task Interface label); adapter type as-is
             "app_display": "AG Manager" if k[1] == IAG4_APP else k[1],
+            "code": k[2],
             "count": c,
-            "recommendation": k[2],
+            "recommendation": k[3],
         }
         for k, c in agg.items()
     ]
-    wf_items.sort(key=lambda x: (x["recommendation"], str(x["key"]), str(x["app"])))
+    # group by code (CODE_ORDER) then name, so the checklist reads in the same order as the legend
+    wf_items.sort(key=lambda x: (CODE_ORDER.index(x["code"]), str(x["key"]), str(x["app"])))
     form_items = [
         {"form_name": f["form_name"], "field_key": f["field_key"],
          "bound_endpoint": f["bound_endpoint"], "recommendation": REC_FORM}

--- a/helpers/iag-migration/analyze_iag4.py
+++ b/helpers/iag-migration/analyze_iag4.py
@@ -28,13 +28,17 @@ import sys
 sys.dont_write_bytecode = True
 
 # --- verbatim recommendation strings (keep in sync with readiness-report-template.md) ---
-REC_ANSIBLE = "register playbook as an IAG5 ansible-playbook service; call via GatewayManager.runService"
-REC_PYTHON = "re-implement as an IAG5 python-script service; call via GatewayManager.runService"
+# NOTE: these strings are rendered into the markdown report, which must NOT contain "iag"/"IAG4"/
+# "IAG5" — use "Gateway4"/"Gateway5" instead. Literal API/app names (GatewayManager.runService,
+# AG Manager) and actual adapter names stay verbatim so the reader can identify them on the platform.
+REC_ANSIBLE = "register playbook as a Gateway5 ansible-playbook service; call via GatewayManager.runService"
+REC_PYTHON = "re-implement as a Gateway5 python-script service; call via GatewayManager.runService"
 REC_SELFMGMT = "move to the Inventory Manager application; drop this task"
-REC_FORM = "rebind to the IAG5/replacement endpoint — returns no data once IAG4 is removed."
-REC_DEVICE = "device sourced from an IAG4 gateway adapter; re-home it in Inventory Manager before removing IAG4"
+REC_FORM = "rebind to the Gateway5/replacement endpoint — returns no data once Gateway4 is removed."
+REC_DEVICE = "device sourced from a Gateway4 adapter; re-home it in Inventory Manager before removing Gateway4"
 
-# IAG4 application name (agmanager). GatewayManager (IAG5) must NEVER be flagged.
+# Gateway4 application name (agmanager). GatewayManager (Gateway5) must NEVER be flagged.
+# (Internal constant name kept as IAG4_APP — script-internal only, never rendered.)
 IAG4_APP = "AGManager"
 # adapter package that identifies the IAG4 automation_gateway adapter
 IAG4_ADAPTER_PACKAGE = "automation_gateway"
@@ -128,6 +132,51 @@ def classify(task):
     return "python-script", REC_PYTHON
 
 
+def task_interface(task):
+    """Which Gateway4 interface a task runs over (req a — needed for Gateway5 cluster mapping):
+      - "AG Manager"  when the task uses the AGManager application (app == "AGManager")
+      - the ACTUAL adapter name otherwise (the adapter-backed automation_gateway task) — returned
+        verbatim from the task's own `app`/`location` so the reader recognizes it on the platform.
+    Only ever called for a task already confirmed IAG4 by is_iag4_task()."""
+    if task.get("app") == IAG4_APP:
+        return "AG Manager"
+    return task.get("app") or task.get("location") or IAG4_ADAPTER_TYPE
+
+
+def find_referrers(tasks, tid):
+    """req (b) — other tasks in the SAME workflow that consume this Gateway4 task's output.
+    A consumer references it either as a `$var.<tid>.<field>` string (wiring an input from its
+    output) or as a structural job reference `{"task":"<tid>", ...}` (childJob / merge / evaluation).
+    Returns [{task_id, task_name}] sorted by task id."""
+    pat_var = re.compile(r"\$var\." + re.escape(tid) + r"\b")
+    pat_task = re.compile(r'"task"\s*:\s*"' + re.escape(tid) + r'"')
+    refs = []
+    for oid, ot in (tasks or {}).items():
+        if oid == tid or oid in ("workflow_start", "workflow_end"):
+            continue
+        blob = json.dumps(ot)
+        if pat_var.search(blob) or pat_task.search(blob):
+            refs.append({"task_id": oid, "task_name": (ot or {}).get("name")})
+    refs.sort(key=lambda x: x["task_id"])
+    return refs
+
+
+def child_workflow_names(tasks):
+    """The workflow NAMES this workflow calls via childJob (req c call-graph edges).
+    A childJob task runs on the WorkFlowEngine app and names its target in
+    variables.incoming.workflow. Returns a sorted, de-duplicated list of names."""
+    names = set()
+    for tid, t in (tasks or {}).items():
+        if tid in ("workflow_start", "workflow_end") or not isinstance(t, dict):
+            continue
+        if t.get("app") != "WorkFlowEngine":
+            continue
+        child = (((t.get("variables") or {}).get("incoming") or {}).get("workflow"))
+        if isinstance(child, str) and child.strip():
+            names.add(child.strip())
+    return sorted(names)
+
+
 _PREFIX_RE = re.compile(r"^@([0-9a-fA-F]+):\s*(.*)$")
 
 
@@ -160,27 +209,98 @@ def wf_location(wf, project_names):
     return "global", None, None, prefix_id, display
 
 
-def in_scope(project_id, prefix_id, display, raw, scope):
+def build_pool(wf_rows, project_names):
+    """Normalize every workflow doc once. Each pool entry carries its display name, id, resolved
+    location, its raw `tasks` map, and the child workflow names it calls (childJob edges)."""
+    pool = []
+    for wf in wf_rows or []:
+        if not isinstance(wf, dict) or not isinstance(wf.get("tasks"), dict):
+            continue
+        raw = wf.get("name") or ""
+        loc_type, project_id, project_name, prefix_id, display = wf_location(wf, project_names)
+        pool.append({
+            "raw": raw,
+            "display": display,
+            "prefix_id": prefix_id,
+            "workflow_id": wf.get("_id"),
+            "location_type": loc_type,
+            "project_id": project_id,
+            "project_name": project_name,
+            "tasks": wf.get("tasks") or {},
+            "child_names": child_workflow_names(wf.get("tasks") or {}),
+        })
+    return pool
+
+
+def seed_indices(pool, scope):
+    """Indices of pool entries that DIRECTLY match the requested scope (before closure)."""
     mode = scope["mode"]
     if mode == "all":
-        return True
+        return set(range(len(pool)))
+    seeds = set()
     if mode == "projects":
-        want = scope["value"]
-        return (project_id in want) or (prefix_id in want)
-    if mode == "workflows":
-        wanted = scope["value"]
-        return raw in wanted or display in wanted
-    return False
+        want = set(scope["value"])
+        for i, w in enumerate(pool):
+            if (w["project_id"] in want) or (w["prefix_id"] in want):
+                seeds.add(i)
+    elif mode == "workflows":
+        want = set(scope["value"])
+        for i, w in enumerate(pool):
+            if w["raw"] in want or w["display"] in want:
+                seeds.add(i)
+    return seeds
+
+
+def resolve_scope(pool, scope):
+    """Transitive-closure scope (req 3): start at the seed workflows and walk DOWN every childJob
+    reference, pulling referenced children into scope — nothing else on the platform is analyzed.
+    Returns (in_scope_indices, unresolved_children) where unresolved_children are child workflow
+    names referenced from in-scope workflows but NOT present in the local pool (drives the skill's
+    scoped-pull loop, and — as a last resort — a report warning)."""
+    name_index = {}
+    for i, w in enumerate(pool):
+        name_index.setdefault(w["display"], []).append(i)
+        if w["raw"] != w["display"]:
+            name_index.setdefault(w["raw"], []).append(i)
+
+    in_scope = set(seed_indices(pool, scope))
+    unresolved = set()
+    queue = list(in_scope)
+    while queue:
+        idx = queue.pop()
+        for child_name in pool[idx]["child_names"]:
+            matches = name_index.get(child_name)
+            if not matches:
+                unresolved.add(child_name)
+                continue
+            for m in matches:
+                if m not in in_scope:
+                    in_scope.add(m)
+                    queue.append(m)
+    return in_scope, sorted(unresolved)
 
 
 def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
-    workflows, n_tasks = [], 0
-    for wf in wf_rows or []:
-        raw = wf.get("name") or ""
-        loc_type, project_id, project_name, prefix_id, display = wf_location(wf, project_names)
-        if not in_scope(project_id, prefix_id, display, raw, scope):
-            continue
-        tasks = wf.get("tasks") or {}
+    pool = build_pool(wf_rows, project_names)
+    in_scope, unresolved_children = resolve_scope(pool, scope)
+
+    # call graph over the IN-SCOPE set only (rule 3 — never look outside scope): display-name -> the
+    # in-scope indices that carry that name, so we can list a child's in-scope parent callers.
+    scope_by_name = {}
+    for i in in_scope:
+        scope_by_name.setdefault(pool[i]["display"], []).append(i)
+    callers = {}  # child index -> [parent index, ...]
+    for i in in_scope:
+        for child_name in pool[i]["child_names"]:
+            for c in scope_by_name.get(child_name, []):
+                callers.setdefault(c, [])
+                if i not in callers[c]:
+                    callers[c].append(i)
+
+    workflows, n_tasks, adapter_names = [], 0, set()
+    for i in sorted(in_scope):
+        w = pool[i]
+        tasks = w["tasks"]
         hits = []
         for tid, t in tasks.items():
             if tid in ("workflow_start", "workflow_end"):
@@ -188,27 +308,69 @@ def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
             if not is_iag4_task(t, instance_ids, prefixes):
                 continue
             iag4_type, rec = classify(t)
+            iface = task_interface(t)
+            if iface != "AG Manager":
+                adapter_names.add(iface)
             hits.append({
                 "task_id": tid,
                 "task_name": t.get("name"),
                 "app": t.get("app"),
                 "summary": t.get("summary"),
-                "iag4_type": iag4_type,
-                "short_recommendation": rec,
+                "interface": iface,                       # req (a): "AG Manager" or actual adapter name
+                "iag4_type": iag4_type,               # internal: used ONLY by the end Repo-Structure section
+                "short_recommendation": rec,          # internal: used ONLY by the end checklist, never the analysis
+                "referenced_by": find_referrers(tasks, tid),  # req (b)
             })
         if hits:
             hits.sort(key=lambda x: x["task_id"])
+            # distinct interfaces (req a) in task-id order — factual AG Manager vs adapter, for the index
+            interfaces = []
+            for h in hits:
+                if h["interface"] not in interfaces:
+                    interfaces.append(h["interface"])
+            called_by = [
+                {"workflow_name": pool[p]["display"], "workflow_id": pool[p]["workflow_id"]}
+                for p in callers.get(i, [])
+            ]
+            called_by.sort(key=lambda x: (x["workflow_name"], x["workflow_id"] or ""))
             workflows.append({
-                "workflow_name": display,
-                "workflow_id": wf.get("_id"),
-                "location_type": loc_type,
-                "project_id": project_id,
-                "project_name": project_name,
+                "workflow_name": w["display"],
+                "workflow_id": w["workflow_id"],
+                "location_type": w["location_type"],
+                "project_id": w["project_id"],
+                "project_name": w["project_name"],
+                "interfaces": interfaces,                 # req (a): distinct interfaces (AG Manager / adapter names)
+                "called_by": called_by,                   # req (c)
                 "tasks": hits,
             })
             n_tasks += len(hits)
     workflows.sort(key=lambda w: (w["workflow_name"], w["project_id"] or "", w["workflow_id"] or ""))
-    return workflows, n_tasks
+    return workflows, n_tasks, unresolved_children, sorted(adapter_names)
+
+
+def group_workflows(workflows):
+    """Group the (already name-sorted) workflows by location so the report can headline each project
+    then list its workflows. Deterministic: projects first (by project name, then id), then Global
+    LAST; workflows within a group keep the flat name/id order. Each group carries a `label`
+    («project_name» (project_id) or "Global") and the same workflow dicts (no data change)."""
+    buckets = {}
+    for w in workflows:
+        if w["location_type"] == "project":
+            key = ("0", w["project_name"] or "", w["project_id"] or "")
+            label = "«%s» (%s)" % (w["project_name"], w["project_id"])
+        else:
+            key = ("1", "", "")
+            label = "Global"
+        if key not in buckets:
+            buckets[key] = {
+                "label": label,
+                "location_type": w["location_type"],
+                "project_id": w.get("project_id"),
+                "project_name": w.get("project_name"),
+                "workflows": [],
+            }
+        buckets[key]["workflows"].append(w)
+    return [buckets[k] for k in sorted(buckets.keys())]
 
 
 def _endpoint_urls(field):
@@ -326,7 +488,14 @@ def build_checklist(workflows, forms):
             key = (t["task_name"], t["app"], t["short_recommendation"])
             agg[key] = agg.get(key, 0) + 1
     wf_items = [
-        {"key": k[0], "app": k[1], "count": c, "recommendation": k[2]}
+        {
+            "key": k[0],
+            "app": k[1],
+            # display app: AGManager -> "AG Manager" (matches the task Interface label); adapter type as-is
+            "app_display": "AG Manager" if k[1] == IAG4_APP else k[1],
+            "count": c,
+            "recommendation": k[2],
+        }
         for k, c in agg.items()
     ]
     wf_items.sort(key=lambda x: (x["recommendation"], str(x["key"]), str(x["app"])))
@@ -338,59 +507,121 @@ def build_checklist(workflows, forms):
     return {"workflows": wf_items, "forms": form_items}
 
 
+def extract_workflows(obj):
+    """Pull workflow docs out of an arbitrary local JSON value so the skill can run against files on
+    disk with no API (local-files-only mode). Handles: a bare workflow doc (has a `tasks` map), a
+    project export (`components[]` where type=="workflow" -> `document`), and list wrappers
+    (`items`/`data`/`results`/`workflows` or a bare array)."""
+    out = []
+    if isinstance(obj, dict):
+        if isinstance(obj.get("tasks"), dict):
+            out.append(obj)
+        for c in obj.get("components") or []:
+            if isinstance(c, dict) and c.get("type") == "workflow" and isinstance(c.get("document"), dict):
+                out.append(c["document"])
+        for key in ("items", "data", "results", "workflows"):
+            v = obj.get(key)
+            if isinstance(v, list):
+                for it in v:
+                    out.extend(extract_workflows(it))
+    elif isinstance(obj, list):
+        for it in obj:
+            out.extend(extract_workflows(it))
+    return out
+
+
+def load_local_workflows(dirs):
+    """Scan every *.json in the given dirs for workflow docs. Deduped by _id (docs without an _id
+    are all kept). Returns a list of workflow docs."""
+    seen_ids, rows = set(), []
+    for d in dirs:
+        if not d or not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            if not fn.endswith(".json"):
+                continue
+            try:
+                obj = load_json(os.path.join(d, fn))
+            except (ValueError, OSError):
+                continue
+            for wf in extract_workflows(obj):
+                wid = wf.get("_id")
+                if wid and wid in seen_ids:
+                    continue
+                if wid:
+                    seen_ids.add(wid)
+                rows.append(wf)
+    return rows
+
+
 def parse_args(argv):
-    p = argparse.ArgumentParser(description="Deterministic IAG4 usage analysis (workflows + JSON forms).")
-    p.add_argument("--tmp", required=True, help="tmp dir holding wf_all.ndjson, apps.json, adapters.json, json-forms.json")
+    p = argparse.ArgumentParser(description="Deterministic Gateway4 usage analysis (workflows + JSON forms).")
+    p.add_argument("--tmp", required=True, help="tmp/output dir; also holds apps.json, adapters.json, json-forms.json and (live mode) wf_all.ndjson")
     p.add_argument("--out", help="output path (default <tmp>/analysis.json)")
+    p.add_argument("--local", action="store_true",
+                   help="local-files-only mode: no API was used; missing/unresolvable data becomes a warning, not a hard error")
+    p.add_argument("--local-dir",
+                   help="comma-separated dirs of *.json workflow/project-export files to scan (local mode); defaults to --tmp")
     g = p.add_mutually_exclusive_group(required=True)
-    g.add_argument("--all", action="store_true", help="scan every workflow")
-    g.add_argument("--projects", help="comma-separated project ids (workflows named @<id>: ...)")
-    g.add_argument("--workflows", help="semicolon-separated workflow names (full or display)")
+    g.add_argument("--all", action="store_true", help="scan every workflow (not recommended — bulk)")
+    g.add_argument("--projects", help="comma-separated project ids (scope seed; closure follows childJob refs)")
+    g.add_argument("--workflows", help="semicolon-separated workflow names (scope seed; closure follows childJob refs)")
     return p.parse_args(argv)
 
 
 def main(argv):
     args = parse_args(argv)
     tmp = args.tmp
+    warnings = []
+
+    # Build the workflow pool. Live mode reads wf_all.ndjson (the scoped/paginated pull). Local mode
+    # (and, additively, any run) reads workflow docs straight from local *.json files (bare workflow
+    # docs, project exports, or list wrappers) so the skill can analyze a working directory with NO
+    # API access at all.
     wf_path = os.path.join(tmp, "wf_all.ndjson")
-    if not os.path.exists(wf_path):
-        sys.stderr.write("error: %s not found — run the skill's pull step first\n" % wf_path)
-        return 2
+    wf_rows = load_ndjson(wf_path) if os.path.exists(wf_path) else []
+    local_dirs = [s.strip() for s in (args.local_dir or "").split(",") if s.strip()] or ([tmp] if args.local else [])
+    if local_dirs:
+        wf_rows = wf_rows + load_local_workflows(local_dirs)
 
-    # An EMPTY wf_all.ndjson is NOT "no IAG4 usage" — it means the workflow pull returned nothing
-    # (almost always a silent auth failure: the OAuth token was sent as a ?token= query param
-    # instead of an 'Authorization: Bearer <token>' header, so every page 401'd and `.items[]`
-    # matched nothing). Fail loudly here rather than emitting a misleading all-zeros report.
-    wf_rows = load_ndjson(wf_path)
-    if not wf_rows:
-        sys.stderr.write(
-            "error: %s is empty — the workflow pull returned 0 workflows. Do NOT trust an all-zeros "
-            "report; the pull failed. For OAuth (AUTH_METHOD=oauth) the token MUST be sent as an "
-            "'Authorization: Bearer <token>' HEADER, never a ?token= query param. Re-run the Step 1 "
-            "pull, confirm the ndjson line count matches the workflows 'total', then re-run this script.\n"
-            % wf_path
-        )
-        return 2
+    has_tasks = any(isinstance(w, dict) and isinstance(w.get("tasks"), dict) for w in wf_rows)
 
-    # A NON-EMPTY ndjson that holds no workflow documents is ALSO a failed pull, not "no IAG4 usage".
-    # The usual cause is a mid-pull auth failure (token expiry, or an OAuth token sent as ?token=
-    # instead of the Bearer header): the paginated GETs return error bodies like
-    # {"message":"Unauthorized"} that parse as JSON and land in the ndjson, so the empty-check above
-    # passes but every row lacks a `tasks` map. Every REAL workflow carries a `tasks` object (at
-    # minimum workflow_start/workflow_end), so if NOT ONE row has one, the file is non-workflow data.
-    # Fail loudly here — otherwise the scan finds nothing and emits a misleading "0 workflows / 0
-    # tasks" report that exits 0 and looks successful. (A platform with genuinely zero IAG4 usage
-    # still has real workflows WITH tasks, so this guard never fires on a legitimate zero result.)
-    if not any(isinstance(w, dict) and isinstance(w.get("tasks"), dict) for w in wf_rows):
-        sys.stderr.write(
-            "error: %s has %d rows but none are workflow documents (no `tasks` object on any row). "
-            "The workflow pull FAILED — almost always a mid-pull auth failure that wrote error bodies "
-            "(e.g. {\"message\":\"Unauthorized\"}) into the ndjson instead of workflows. Do NOT trust a "
-            "0-workflow report. For OAuth the token MUST be an 'Authorization: Bearer <token>' HEADER "
-            "(never a ?token= query param); confirm the ndjson line count matches the workflows "
-            "'total', then re-run this script.\n" % (wf_path, len(wf_rows))
-        )
-        return 2
+    if args.local:
+        # LOCAL mode — never hard-fail on missing/empty data (req 4: analyze what's on disk, warn as a
+        # last resort). If there is nothing to analyze, emit an empty report WITH a warning, exit 0.
+        if not has_tasks:
+            warnings.append(
+                "local mode: no workflow documents found on disk (looked in: %s) — nothing to analyze. "
+                "Point --local-dir at a directory of workflow/project-export JSON files." % ", ".join(local_dirs)
+            )
+    else:
+        # LIVE mode — an empty or non-workflow ndjson is a FAILED PULL, not "no Gateway4 usage"
+        # (almost always a silent auth failure: an OAuth token sent as a ?token= query param instead
+        # of the 'Authorization: Bearer <token>' header, so every page 401'd). Fail loudly rather
+        # than emitting a misleading all-zeros report. (A platform with genuinely zero Gateway4 usage
+        # still has real workflows WITH a `tasks` object, so this guard never fires on a legit zero.)
+        if not os.path.exists(wf_path):
+            sys.stderr.write("error: %s not found — run the skill's pull step first (or pass --local)\n" % wf_path)
+            return 2
+        if not wf_rows:
+            sys.stderr.write(
+                "error: %s is empty — the workflow pull returned 0 workflows. Do NOT trust an all-zeros "
+                "report; the pull failed. For OAuth (AUTH_METHOD=oauth) the token MUST be sent as an "
+                "'Authorization: Bearer <token>' HEADER, never a ?token= query param. Re-run the Step 1 "
+                "pull, confirm the ndjson line count matches the workflows 'total', then re-run this script.\n"
+                % wf_path
+            )
+            return 2
+        if not has_tasks:
+            sys.stderr.write(
+                "error: %s has %d rows but none are workflow documents (no `tasks` object on any row). "
+                "The workflow pull FAILED — almost always a mid-pull auth failure that wrote error bodies "
+                "(e.g. {\"message\":\"Unauthorized\"}) into the ndjson instead of workflows. Do NOT trust a "
+                "0-workflow report. For OAuth the token MUST be an 'Authorization: Bearer <token>' HEADER "
+                "(never a ?token= query param); confirm the ndjson line count matches the workflows "
+                "'total', then re-run this script.\n" % (wf_path, len(wf_rows))
+            )
+            return 2
 
     if args.all:
         scope = {"mode": "all", "value": None}
@@ -401,19 +632,32 @@ def main(argv):
 
     adapter_type, instance_ids, prefixes = resolve_identifiers(os.path.join(tmp, "adapters.json"))
     project_names = load_project_names(os.path.join(tmp, "projects.json"))
-    workflows, n_tasks = scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names)
+    workflows, n_tasks, unresolved_children, adapter_names = scan_workflows(
+        wf_rows, instance_ids, prefixes, scope, project_names)
     forms = scan_forms(os.path.join(tmp, "json-forms.json"), prefixes)
     devices = scan_devices(os.path.join(tmp, "devices.json"), instance_ids)
     checklist = build_checklist(workflows, forms)
+
+    # Referenced child workflows we could NOT find in the pool. In live mode the skill's closure loop
+    # should pull them and re-run; anything still unresolved (or all of them in local mode) becomes a
+    # last-resort report warning — the skill must NOT invent what those workflows contain.
+    if unresolved_children:
+        warnings.append(
+            "referenced child workflow(s) not available for analysis: %s — could not follow these "
+            "childJob references. Pull them into scope (live) or add their JSON to --local-dir, then "
+            "re-run. Do NOT assume their contents." % ", ".join(unresolved_children)
+        )
 
     result = {
         "identifiers": {
             "adapter_type": adapter_type,
             "adapter_instances": instance_ids,
             "adapter_route_prefixes": prefixes,
+            "adapter_display_names": adapter_names,
             "app": IAG4_APP,
         },
         "scope": scope,
+        "mode": "local" if args.local else "live",
         "counts": {
             "n_workflows": len(workflows),
             "n_iag4_tasks": n_tasks,
@@ -421,9 +665,12 @@ def main(argv):
             "n_iag4_devices": devices["n_iag4"],
         },
         "workflows": workflows,
+        "workflow_groups": group_workflows(workflows),
         "forms": forms,
         "devices": devices,
         "checklist": checklist,
+        "unresolved_children": unresolved_children,
+        "warnings": warnings,
     }
 
     out = args.out or os.path.join(tmp, "analysis.json")
@@ -432,8 +679,10 @@ def main(argv):
         fh.write("\n")
 
     sys.stderr.write(
-        "analyzed scope=%s -> %d workflows, %d IAG4 tasks, %d IAG4 form fields, %d IAG4-origin devices -> %s\n"
-        % (scope["mode"], len(workflows), n_tasks, len(forms), devices["n_iag4"], out)
+        "analyzed mode=%s scope=%s -> %d workflows, %d Gateway4 tasks, %d Gateway4 form fields, "
+        "%d Gateway4-origin devices, %d unresolved children -> %s\n"
+        % (result["mode"], scope["mode"], len(workflows), n_tasks, len(forms),
+           devices["n_iag4"], len(unresolved_children), out)
     )
     return 0
 

--- a/helpers/iag-migration/analyze_iag4.py
+++ b/helpers/iag-migration/analyze_iag4.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Deterministic IAG4 usage analysis for the /iag4-to-iag5 skill.
+
+Pure analysis over already-pulled data in a working directory's tmp/ folder. Reads
+wf_all.ndjson, apps.json, adapters.json and json-forms.json; resolves the IAG4
+identifiers, applies a scope filter, scans workflows and JSON forms, classifies each
+IAG4 reference, and writes a sorted, structured analysis.json.
+
+Read-only: the ONLY file this writes is the --out analysis JSON (default <tmp>/analysis.json).
+It never touches IAP/IAG and never re-pulls data. Scripts + inventory analysis stay with
+the skill's AI. The report is rendered by the skill from this JSON.
+
+The recommendation strings below are the single source of truth and MUST stay identical to
+helpers/iag-migration/readiness-report-template.md.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# don't write bytecode for anything this process imports (belt-and-suspenders; the skill also
+# invokes us with `python3 -B`, which is what actually prevents a __pycache__ for this module).
+sys.dont_write_bytecode = True
+
+# --- verbatim recommendation strings (keep in sync with readiness-report-template.md) ---
+REC_ANSIBLE = "register playbook as an IAG5 ansible-playbook service; call via GatewayManager.runService"
+REC_PYTHON = "re-implement as an IAG5 python-script service; call via GatewayManager.runService"
+REC_SELFMGMT = "move to the Inventory Manager application; drop this task"
+REC_FORM = "rebind to the IAG5/replacement endpoint — returns no data once IAG4 is removed."
+REC_DEVICE = "device sourced from an IAG4 gateway adapter; re-home it in Inventory Manager before removing IAG4"
+
+# IAG4 application name (agmanager). GatewayManager (IAG5) must NEVER be flagged.
+IAG4_APP = "AGManager"
+# adapter package that identifies the IAG4 automation_gateway adapter
+IAG4_ADAPTER_PACKAGE = "automation_gateway"
+# canonical adapter type token as it appears on workflow tasks' `app` field
+IAG4_ADAPTER_TYPE = "AutomationGateway"
+
+# self-management: device/group inventory ops that go away in IAG5
+_SELFMGMT_RE = re.compile(
+    r"(add|create|remove|delete|update|get|list)[_\s-]*(device|group)s?\b|"
+    r"\b(device|group)[_\s-]*(add|create|remove|delete|update|management)\b",
+    re.IGNORECASE,
+)
+_PLAYBOOK_RE = re.compile(r"\b(playbook|role)\b", re.IGNORECASE)
+# form endpoint tokens that indicate an IAG4 binding
+_FORM_IAG4_TOKENS = ("automationgateway", "automation_gateway", "automation-gateway", "agmanager")
+
+
+def _norm(s):
+    return re.sub(r"[\s_-]", "", (s or "").lower())
+
+
+def load_ndjson(path):
+    rows = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def load_json(path):
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def resolve_identifiers(adapters_path):
+    """Return (adapter_type, sorted instance ids, routePrefixes) for the IAG4 adapter."""
+    instances, prefixes = set(), set()
+    if adapters_path and os.path.exists(adapters_path):
+        data = load_json(adapters_path)
+        results = data.get("results") if isinstance(data, dict) else data
+        for a in results or []:
+            if IAG4_ADAPTER_PACKAGE in str(a.get("package_id", "")):
+                if a.get("id"):
+                    instances.add(a["id"])
+                if a.get("routePrefix"):
+                    prefixes.add(a["routePrefix"])
+    return IAG4_ADAPTER_TYPE, sorted(instances), sorted(prefixes)
+
+
+def load_project_names(projects_path):
+    """Return {project_id: name} from projects.json. The project list wrapper varies by endpoint
+    (`data`, `items`, `results`, or a bare array), so probe each. Missing/orphaned/deleted project
+    ids simply won't be in the map — the caller falls back to the bare id."""
+    names = {}
+    if projects_path and os.path.exists(projects_path):
+        data = load_json(projects_path)
+        if isinstance(data, dict):
+            rows = data.get("data") or data.get("items") or data.get("results") or []
+        else:
+            rows = data or []
+        for p in rows:
+            if isinstance(p, dict) and p.get("_id"):
+                names[p["_id"]] = p.get("name")
+    return names
+
+
+def is_iag4_task(task, instance_ids, prefixes):
+    """True if a workflow task references IAG4 (adapter or AGManager app). Never GatewayManager."""
+    app = task.get("app")
+    loc = task.get("location")
+    if app == "GatewayManager":
+        return False
+    if app == IAG4_APP:
+        return True
+    if _norm(app) == _norm(IAG4_ADAPTER_TYPE):
+        return True
+    if app in instance_ids or loc in instance_ids:
+        return True
+    return False
+
+
+def classify(task):
+    """Return (iag4_type, short_recommendation) for an IAG4 task."""
+    hay = " ".join(str(task.get(k) or "") for k in ("name", "summary", "description", "canvasName"))
+    if _SELFMGMT_RE.search(hay):
+        return "self-management", REC_SELFMGMT
+    if _PLAYBOOK_RE.search(hay):
+        return "ansible-playbook", REC_ANSIBLE
+    return "python-script", REC_PYTHON
+
+
+_PREFIX_RE = re.compile(r"^@([0-9a-fA-F]+):\s*(.*)$")
+
+
+def split_name(raw):
+    """(project_id or None, display_name) from a workflow/form name."""
+    m = _PREFIX_RE.match(raw or "")
+    if m:
+        return m.group(1), m.group(2)
+    return None, (raw or "")
+
+
+def wf_location(wf, project_names):
+    """Resolve a workflow's project membership from the authoritative `namespace` field.
+
+    A workflow is IN A PROJECT iff `namespace` is a project object (carries the live `_id`
+    and `name`); then the report shows that name. Otherwise it is GLOBAL — even if its NAME
+    still starts with a stale `@<id>:` prefix (a leftover string from a bulk import whose
+    project was deleted). The name prefix alone is NOT proof of project membership.
+
+    Returns (location_type, project_id, project_name, prefix_id, display_name).
+    """
+    raw = wf.get("name") or ""
+    prefix_id, display = split_name(raw)
+    ns = wf.get("namespace")
+    if isinstance(ns, dict) and ns.get("type") == "project" and ns.get("_id"):
+        return "project", ns.get("_id"), ns.get("name"), prefix_id, display
+    # defensive fallback: no namespace, but the name prefix resolves to a live project
+    if prefix_id and prefix_id in project_names:
+        return "project", prefix_id, project_names.get(prefix_id), prefix_id, display
+    return "global", None, None, prefix_id, display
+
+
+def in_scope(project_id, prefix_id, display, raw, scope):
+    mode = scope["mode"]
+    if mode == "all":
+        return True
+    if mode == "projects":
+        want = scope["value"]
+        return (project_id in want) or (prefix_id in want)
+    if mode == "workflows":
+        wanted = scope["value"]
+        return raw in wanted or display in wanted
+    return False
+
+
+def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
+    workflows, n_tasks = [], 0
+    for wf in wf_rows or []:
+        raw = wf.get("name") or ""
+        loc_type, project_id, project_name, prefix_id, display = wf_location(wf, project_names)
+        if not in_scope(project_id, prefix_id, display, raw, scope):
+            continue
+        tasks = wf.get("tasks") or {}
+        hits = []
+        for tid, t in tasks.items():
+            if tid in ("workflow_start", "workflow_end"):
+                continue
+            if not is_iag4_task(t, instance_ids, prefixes):
+                continue
+            iag4_type, rec = classify(t)
+            hits.append({
+                "task_id": tid,
+                "task_name": t.get("name"),
+                "app": t.get("app"),
+                "summary": t.get("summary"),
+                "iag4_type": iag4_type,
+                "short_recommendation": rec,
+            })
+        if hits:
+            hits.sort(key=lambda x: x["task_id"])
+            workflows.append({
+                "workflow_name": display,
+                "workflow_id": wf.get("_id"),
+                "location_type": loc_type,
+                "project_id": project_id,
+                "project_name": project_name,
+                "tasks": hits,
+            })
+            n_tasks += len(hits)
+    workflows.sort(key=lambda w: (w["workflow_name"], w["project_id"] or "", w["workflow_id"] or ""))
+    return workflows, n_tasks
+
+
+def _endpoint_urls(field):
+    """Collect the REST endpoint path(s) a form field binds to. ONLY the endpoint URL matters —
+    base+href, originalHref, links[].href, and the binding:hyperSchema mirror. We deliberately do
+    NOT look inside the request body (e.g. body.options.adapterType): a Configuration Manager query
+    that FILTERS by adapterType is a CM endpoint, not an IAG4-bound endpoint, and must not be flagged.
+    """
+    urls = []
+    if not isinstance(field, dict):
+        return urls
+    base = field.get("base") or ""
+    if field.get("base") or field.get("href"):
+        urls.append(base + (field.get("href") or ""))
+    if field.get("originalHref"):
+        urls.append(base + field["originalHref"])
+    for lk in field.get("links") or []:
+        if isinstance(lk, dict) and lk.get("href"):
+            urls.append(base + lk["href"])
+    hs = field.get("binding:hyperSchema") or field.get("hyperSchema")
+    if isinstance(hs, dict):
+        hb = hs.get("base") or ""
+        if hs.get("base"):
+            urls.append(hb)
+        for lk in hs.get("links") or []:
+            if isinstance(lk, dict) and lk.get("href"):
+                urls.append(hb + lk["href"])
+    return urls
+
+
+def _endpoint_iag4_token(field, tokens):
+    """Return (matched_token, endpoint_url) if any of the field's endpoints points at IAG4."""
+    for url in _endpoint_urls(field):
+        norm = _norm(url)
+        for tok in tokens:
+            if tok and tok in norm:
+                return tok, url
+    return None
+
+
+def scan_forms(forms_path, prefixes):
+    """Flag form fields whose BINDING ENDPOINT points at the IAG4 automation_gateway adapter or the
+    agmanager app — dropdowns and any other REST-bound field alike. Matching is on the endpoint URL
+    only, never the request body: a form bound to /configuration_manager/... that merely filters by
+    adapterType=AutomationGateway is a Config Manager form, NOT an IAG4-bound form."""
+    forms = []
+    if not (forms_path and os.path.exists(forms_path)):
+        return forms
+    tokens = tuple(_FORM_IAG4_TOKENS) + tuple(_norm(p) for p in (prefixes or []))
+    for f in load_json(forms_path) or []:
+        raw = f.get("name") or ""
+        _, display = split_name(raw)
+        struct = f.get("struct") or {}
+        binding_props = (f.get("bindingSchema") or {}).get("properties") or {}
+        seen_keys = set()
+
+        # visible fields (struct.items[]) — check each field's binding endpoint
+        for item in struct.get("items") or []:
+            if not isinstance(item, dict):
+                continue
+            hit = _endpoint_iag4_token(item, tokens)
+            if not hit:
+                continue
+            field_key = item.get("title") or item.get("nodeId") or "(field)"
+            seen_keys.add(field_key)
+            forms.append({
+                "form_name": display,
+                "field_key": field_key,
+                "bound_endpoint": hit[1],
+                "matched_on": hit[0],
+            })
+
+        # bindingSchema mirror — catch fields whose endpoint lives only in the backing schema
+        for key, v in binding_props.items():
+            if key in seen_keys or not isinstance(v, dict):
+                continue
+            hit = _endpoint_iag4_token(v, tokens)
+            if hit:
+                forms.append({
+                    "form_name": display,
+                    "field_key": key,
+                    "bound_endpoint": hit[1],
+                    "matched_on": hit[0],
+                })
+    forms.sort(key=lambda x: (x["form_name"], str(x["field_key"])))
+    return forms
+
+
+def scan_devices(devices_path, instance_ids):
+    """Flag Configuration Manager devices whose origin/broker is an IAG4 gateway adapter.
+    devices.json shape: {"list":[{"name":..., "origins":[adapter_instance,...]}]}."""
+    flagged, total, iag4_set = [], 0, set(instance_ids)
+    if not (devices_path and os.path.exists(devices_path)):
+        return {"present": False, "n_devices": 0, "n_iag4": 0, "devices": []}
+    data = load_json(devices_path)
+    rows = data.get("list") if isinstance(data, dict) else data
+    for dev in rows or []:
+        total += 1
+        origins = dev.get("origins") or ([dev.get("origin")] if dev.get("origin") else [])
+        iag4_origins = sorted({o for o in origins if o in iag4_set})
+        if iag4_origins:
+            flagged.append({
+                "device_name": dev.get("name"),
+                "origins": iag4_origins,
+                "recommendation": REC_DEVICE,
+            })
+    flagged.sort(key=lambda d: (str(d["device_name"]), str(d["origins"])))
+    return {"present": True, "n_devices": total, "n_iag4": len(flagged), "devices": flagged}
+
+
+def build_checklist(workflows, forms):
+    agg = {}
+    for w in workflows:
+        for t in w["tasks"]:
+            key = (t["task_name"], t["app"], t["short_recommendation"])
+            agg[key] = agg.get(key, 0) + 1
+    wf_items = [
+        {"key": k[0], "app": k[1], "count": c, "recommendation": k[2]}
+        for k, c in agg.items()
+    ]
+    wf_items.sort(key=lambda x: (x["recommendation"], str(x["key"]), str(x["app"])))
+    form_items = [
+        {"form_name": f["form_name"], "field_key": f["field_key"],
+         "bound_endpoint": f["bound_endpoint"], "recommendation": REC_FORM}
+        for f in forms
+    ]
+    return {"workflows": wf_items, "forms": form_items}
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description="Deterministic IAG4 usage analysis (workflows + JSON forms).")
+    p.add_argument("--tmp", required=True, help="tmp dir holding wf_all.ndjson, apps.json, adapters.json, json-forms.json")
+    p.add_argument("--out", help="output path (default <tmp>/analysis.json)")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--all", action="store_true", help="scan every workflow")
+    g.add_argument("--projects", help="comma-separated project ids (workflows named @<id>: ...)")
+    g.add_argument("--workflows", help="semicolon-separated workflow names (full or display)")
+    return p.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    tmp = args.tmp
+    wf_path = os.path.join(tmp, "wf_all.ndjson")
+    if not os.path.exists(wf_path):
+        sys.stderr.write("error: %s not found — run the skill's pull step first\n" % wf_path)
+        return 2
+
+    # An EMPTY wf_all.ndjson is NOT "no IAG4 usage" — it means the workflow pull returned nothing
+    # (almost always a silent auth failure: the OAuth token was sent as a ?token= query param
+    # instead of an 'Authorization: Bearer <token>' header, so every page 401'd and `.items[]`
+    # matched nothing). Fail loudly here rather than emitting a misleading all-zeros report.
+    wf_rows = load_ndjson(wf_path)
+    if not wf_rows:
+        sys.stderr.write(
+            "error: %s is empty — the workflow pull returned 0 workflows. Do NOT trust an all-zeros "
+            "report; the pull failed. For OAuth (AUTH_METHOD=oauth) the token MUST be sent as an "
+            "'Authorization: Bearer <token>' HEADER, never a ?token= query param. Re-run the Step 1 "
+            "pull, confirm the ndjson line count matches the workflows 'total', then re-run this script.\n"
+            % wf_path
+        )
+        return 2
+
+    # A NON-EMPTY ndjson that holds no workflow documents is ALSO a failed pull, not "no IAG4 usage".
+    # The usual cause is a mid-pull auth failure (token expiry, or an OAuth token sent as ?token=
+    # instead of the Bearer header): the paginated GETs return error bodies like
+    # {"message":"Unauthorized"} that parse as JSON and land in the ndjson, so the empty-check above
+    # passes but every row lacks a `tasks` map. Every REAL workflow carries a `tasks` object (at
+    # minimum workflow_start/workflow_end), so if NOT ONE row has one, the file is non-workflow data.
+    # Fail loudly here — otherwise the scan finds nothing and emits a misleading "0 workflows / 0
+    # tasks" report that exits 0 and looks successful. (A platform with genuinely zero IAG4 usage
+    # still has real workflows WITH tasks, so this guard never fires on a legitimate zero result.)
+    if not any(isinstance(w, dict) and isinstance(w.get("tasks"), dict) for w in wf_rows):
+        sys.stderr.write(
+            "error: %s has %d rows but none are workflow documents (no `tasks` object on any row). "
+            "The workflow pull FAILED — almost always a mid-pull auth failure that wrote error bodies "
+            "(e.g. {\"message\":\"Unauthorized\"}) into the ndjson instead of workflows. Do NOT trust a "
+            "0-workflow report. For OAuth the token MUST be an 'Authorization: Bearer <token>' HEADER "
+            "(never a ?token= query param); confirm the ndjson line count matches the workflows "
+            "'total', then re-run this script.\n" % (wf_path, len(wf_rows))
+        )
+        return 2
+
+    if args.all:
+        scope = {"mode": "all", "value": None}
+    elif args.projects:
+        scope = {"mode": "projects", "value": [s.strip() for s in args.projects.split(",") if s.strip()]}
+    else:
+        scope = {"mode": "workflows", "value": [s.strip() for s in args.workflows.split(";") if s.strip()]}
+
+    adapter_type, instance_ids, prefixes = resolve_identifiers(os.path.join(tmp, "adapters.json"))
+    project_names = load_project_names(os.path.join(tmp, "projects.json"))
+    workflows, n_tasks = scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names)
+    forms = scan_forms(os.path.join(tmp, "json-forms.json"), prefixes)
+    devices = scan_devices(os.path.join(tmp, "devices.json"), instance_ids)
+    checklist = build_checklist(workflows, forms)
+
+    result = {
+        "identifiers": {
+            "adapter_type": adapter_type,
+            "adapter_instances": instance_ids,
+            "adapter_route_prefixes": prefixes,
+            "app": IAG4_APP,
+        },
+        "scope": scope,
+        "counts": {
+            "n_workflows": len(workflows),
+            "n_iag4_tasks": n_tasks,
+            "n_forms": len(forms),
+            "n_iag4_devices": devices["n_iag4"],
+        },
+        "workflows": workflows,
+        "forms": forms,
+        "devices": devices,
+        "checklist": checklist,
+    }
+
+    out = args.out or os.path.join(tmp, "analysis.json")
+    with open(out, "w") as fh:
+        json.dump(result, fh, indent=2, sort_keys=False)
+        fh.write("\n")
+
+    sys.stderr.write(
+        "analyzed scope=%s -> %d workflows, %d IAG4 tasks, %d IAG4 form fields, %d IAG4-origin devices -> %s\n"
+        % (scope["mode"], len(workflows), n_tasks, len(forms), devices["n_iag4"], out)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/helpers/iag-migration/analyze_iag4.py
+++ b/helpers/iag-migration/analyze_iag4.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import sys
+sys.dont_write_bytecode = True
+
 """Deterministic IAG4 usage analysis for the /iag4-to-iag5 skill.
 
 Pure analysis over already-pulled data in a working directory's tmp/ folder. Reads

--- a/helpers/iag-migration/readiness-report-template.md
+++ b/helpers/iag-migration/readiness-report-template.md
@@ -1,41 +1,66 @@
 <!--
-IAG4 → IAG5 Readiness Report — FIXED TEMPLATE.
+Gateway4 → Gateway5 Readiness Report — FIXED TEMPLATE.
 The iag4-to-iag5 skill fills this in. Keep section order and headings identical every run so
 the same inputs always produce a byte-identical report (aside from the header metadata line).
 Canonical section order (also the Table of Contents at the top): Summary, Workflows, JSON Forms,
 Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure, Manual Action Checklist.
-The checklist is LAST (after Recommended Repository Structure). The TOC links to each section.
+The checklist is LAST. The TOC links to each section.
 Placeholders are wrapped in {{ }}. Every section is ALWAYS rendered — if a section has no
-findings, emit its "No IAG4 references found." line instead of dropping the section.
-Sort rules: workflows by name (asc), then project id, then workflow id; tasks within a workflow by task id (asc),
-forms by name (asc), IAG4 assets by filename (asc), devices by name (asc), checklist by section
-then name. No per-row timestamps. The script (analyze_iag4.py) already applies every sort — render
-straight from analysis.json.
-Keep it terse — this is a working checklist, not a narrative. No read-only banners, no "two
-rules" preamble, no per-workflow tables. Those belong in the skill, not the report.
-Short recommendation strings are FIXED (verbatim) for determinism — they are the module-level
-constants in analyze_iag4.py; keep both in sync:
-  - ansible-playbook task:  register playbook as an IAG5 ansible-playbook service; call via GatewayManager.runService
-  - python-script task:     re-implement as an IAG5 python-script service; call via GatewayManager.runService
+findings, emit its "No Gateway4 references found." line instead of dropping the section.
+
+DESIGN: the ANALYSIS sections (Workflows, JSON Forms, Inventory) are PURE FACTS — what is on the
+platform, nothing inferred, nothing recommended. No per-task "what to do", no remediation codes, no
+legend. The only forward-looking / suggested content lives in the two clearly-labelled sections at
+the END — Recommended Repository Structure and Manual Action Checklist. Never move recommendation
+text into the analysis tables.
+
+WORDING RULE (hard): the rendered report must NOT contain "iag", "IAG4", or "IAG5". Use
+"Itential Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5". Keep literal API/app names
+(GatewayManager.runService, AG Manager) and the ACTUAL adapter names verbatim so the reader can
+identify them on the platform. (Scripts/variable names may still use IAG internally — never rendered.)
+
+FIXED recommendation strings — used ONLY in the end checklist / repo section, NEVER the analysis.
+They are the VERBATIM REC_* constants in analyze_iag4.py; keep both in sync (determinism contract):
   - self-management task:   move to the Inventory Manager application; drop this task
-  - json form field:        rebind to the IAG5/replacement endpoint — returns no data once IAG4 is removed.
-  - iag4-origin device:     device sourced from an IAG4 gateway adapter; re-home it in Inventory Manager before removing IAG4
+  - python-script task:     re-implement as a Gateway5 python-script service; call via GatewayManager.runService
+  - ansible-playbook task:  register playbook as a Gateway5 ansible-playbook service; call via GatewayManager.runService
+  - json form field:        rebind to the Gateway5/replacement endpoint — returns no data once Gateway4 is removed.
+  - gateway4-origin device:  device sourced from a Gateway4 adapter; re-home it in Inventory Manager before removing Gateway4
   - python asset (argv):    convert positional args to argparse flags; place in a git repo
   - python asset (argparse):already uses named args; place in a git repo
   - shell asset:            wrap in a Python script (python-script service) or register as an executable service; place in a git repo
   - role asset:             wrap in a playbook or Python script; place in a git repo
   - playbook asset:         place in a git repo; no code change
+
+Sort rules (analyze_iag4.py already applies them — render straight through): workflows by name (asc),
+then project id, then workflow id; tasks within a workflow by task id (asc); checklist by
+recommendation then name; forms by name; assets by filename; devices by name; unresolved_children as
+given (sorted). No per-row timestamps.
+
 Workflow location comes from the workflow's `namespace` field (authoritative project membership):
 "Global" when not project-owned, else "«{project_name}» ({project_id})". A stale @id: name prefix
-is NOT project membership — those are Global. Never emit "name unavailable".
+is NOT project membership — those are Global. Never emit "name unavailable". Location is rendered the
+SAME way everywhere (index Scope/Connector column AND detail heading) — the project id is kept.
 -->
 
-# IAG4 → IAG5 Migration Readiness
+# Itential Gateway4 → Itential Gateway5 Migration Readiness
 
-**Generated:** {{YYYY-MM-DD}} · **Working dir:** {{working_dir}}
-**IAP source:** {{iap_source}} · **IAG4 assets:** {{iag4_source}}
-**IAG4 matched:** adapter `{{adapter_type}}` (instances: {{adapter_instances}}), app `{{agmanager_app}}`
-**Scope:** {{scope_description}}
+| | |
+|---|---|
+| **Generated** | {{YYYY-MM-DD}} |
+| **Working directory** | `{{working_dir}}` |
+| **Mode** | {{mode}} |
+| **Platform source** | {{iap_source}} |
+| **Gateway4 assets** | {{gateway4_assets_source}} |
+| **Gateway4 matched** | Adapter `{{adapter_type}}` (instances: {{adapter_instances}}) · App `AG Manager` |
+| **Scope** | {{scope_description}} |
+
+<!-- DATA-GAP callout — render ONLY if analysis.json.unresolved_children is non-empty. One short line
+     pointing to the full list at the BOTTOM (do NOT dump the whole list here — that was the old,
+     unreadable behavior). If analysis.json.warnings has entries NOT about unresolved children (e.g.
+     local-mode "nothing found"), render those as extra "> **Warning:** …" lines. Omit entirely when
+     there is nothing to flag. -->
+> **⚠ Data gap — {{n_unresolved}} referenced child workflow(s) could not be analyzed.** Their contents were not followed and must not be assumed. The full list is in [Manual Action Checklist → General](#general). Pull them into scope (live) or add their JSON to `--local-dir`, then re-run this report.
 
 ## Contents
 
@@ -51,59 +76,104 @@ is NOT project membership — those are Global. Never emit "name unavailable".
 
 | Metric | Count |
 |---|---|
-| Workflows referencing IAG4 | {{n_workflows}} |
-| IAG4 tasks | {{n_iag4_tasks}} |
-| JSON form fields bound to IAG4 | {{n_forms}} |
-| Config Manager devices sourced from IAG4 | {{n_iag4_devices}} |
-| IAG4 scripts/playbooks/roles (local) | {{n_assets}} |
-| IAG4 inventory | {{inventory_status}} |
+| Workflows referencing Gateway4 | {{n_workflows}} |
+| Gateway4 tasks | {{n_gw4_tasks}} |
+| JSON form fields bound to Gateway4 | {{n_forms}} |
+| Config Manager devices sourced from Gateway4 | {{n_gw4_devices}} |
+| Gateway4 scripts/playbooks/roles (local) | {{n_assets}} |
+| Referenced workflows not analyzed (unresolved) | {{n_unresolved}} |
+| Gateway4 inventory | {{inventory_status}} |
 
 ## Workflows
 
-<!-- One TABLE, ONE ROW PER WORKFLOW (not per task). All of a workflow's IAG4 tasks go in the last
-     cell, one per line, joined by literal <br>. This keeps each workflow on a single row so a
-     reader can instantly see which workflows have >1 IAG4 task, even when several workflows share
-     the same NAME (the same use case cloned across places) — `workflow_id` is what distinguishes
-     them; they are distinct workflows, not a pull artifact. Location is the project NAME when the
-     workflow's `namespace` marks it as project-owned (project id in parens for disambiguation);
-     when `location_type` is "global" (no live project — includes workflows whose name carries a
-     stale @id: prefix for a deleted project) Location is exactly "Global". Never emit "name
-     unavailable". Rows sorted by workflow name, then project id, then workflow id; tasks within the
-     cell by task id (the script already applies this — render straight through). -->
-| Workflow | Workflow ID | Location | IAG4 Tasks & Recommendations |
+<!-- PURE-FACTS analysis section — NO recommendations, NO codes, NO "what to do". Just what is on the
+     platform. GROUPED BY LOCATION: iterate analysis.json.workflow_groups (already ordered — projects
+     first by name, then a final "Global" group; workflows within a group already name-sorted). Do
+     NOT recompute or re-sort.
+
+     For EACH group:
+       ### {{group.label}}
+         group.label = "«{project_name}» ({project_id})" for a project, or "Global" for the
+         not-in-a-project group. The project/Global identity lives HERE, so it is NOT repeated in the
+         per-workflow rows below (no "Scope / Connector" column, no location in the detail heading).
+
+       an INDEX TABLE for that group's workflows (project context is the headline, so it's dropped):
+         | Workflow | Tasks | Interface(s) | ID |
+         | `{{workflow_name}}` | {{n_tasks}} | {{interfaces joined ", "}} | `{{workflow_id}}` |
+         - Interface(s) = workflow.interfaces (distinct, task order) joined ", " — FACT from the data:
+           "AG Manager" (AGManager application) and/or the ACTUAL adapter name(s); what the reader
+           needs for Gateway5 cluster mapping. No recommendation implied.
+         - ALWAYS print `workflow_id` (disambiguates the same use case cloned across places — identical
+           names, distinct ids; real distinct workflows, not a pull artifact).
+
+       then ONE `####` DETAIL SECTION per workflow in the group:
+         #### `{{workflow_name}}` · `{{workflow_id}}`      (no location — the group headline carries it)
+         a 3-col table, ONE ROW PER TASK (facts only):
+           | Task | Name | Interface |
+           | `{{task_id}}` | {{task_name}} | {{interface}} |
+         `interface` (req a) = exactly "AG Manager" or the ACTUAL adapter name (verbatim).
+
+         References — collect the relationship lines for this workflow, in this order:
+            (1) if called_by (req c) non-empty: "Called by `{{name}}` (`{{id}}`), `{{name}}` (`{{id}}`)"
+                (IN-SCOPE parents only — the scan never looks outside the requested scope)
+            (2) for each task whose referenced_by (req b) is non-empty:
+                "`{{task_id}}` output used by `{{ref_id}}`, `{{ref_id}}`"
+           Zero lines → render nothing. Exactly ONE line → inline "**References:** <line>". MORE than
+           one → a "**References:**" header then a bullet per line. -->
+{{n_workflows}} workflows reference Gateway4 tasks ({{n_gw4_tasks}} tasks total), grouped by project below (Global workflows last). Each project lists its workflows, then per-workflow task detail and cross-references.
+
+{{#each group}}
+### {{group.label}}
+
+| Workflow | Tasks | Interface(s) | ID |
 |---|---|---|---|
-{{#each workflow}}| {{workflow_name}} | `{{workflow_id}}` | {{location}} | {{#join task with <br>}}`{{task_id}}` **{{task_name}}** — {{short_recommendation}}{{/join}} |
+{{#each group.workflow}}| `{{workflow_name}}` | {{n_tasks}} | {{interfaces}} | `{{workflow_id}}` |
 {{/each}}
-<!-- location cell: "Global", or "«{project_name}» ({project_id})" when location_type == "project".
-     tasks cell: for each task `{{task_id}}` **{{task_name}}** — {{short_recommendation}}, joined by <br>. -->
-<!-- if none: --> {{none_workflows}}  <!-- "No IAG4 references found." -->
+
+{{#each group.workflow}}
+#### `{{workflow_name}}` · `{{workflow_id}}`
+
+| Task | Name | Interface |
+|---|---|---|
+{{#each task}}| `{{task_id}}` | {{task_name}} | {{interface}} |
+{{/each}}
+{{references_block}}
+{{/each}}
+{{/each}}
+<!-- if none (workflow_groups empty): --> {{none_workflows}}  <!-- "No Gateway4 references found." -->
 
 ## JSON Forms
 
-<!-- Any form field whose endpoint/body/validation points at the automation_gateway adapter or the
-     agmanager app — REST-bound dropdowns AND non-dropdown fields alike. -->
-{{#each form}}- **{{form_name}}** — {{field_key}} (`{{bound_endpoint}}`): rebind to the IAG5/replacement endpoint — returns no data once IAG4 is removed.
+<!-- Any form field whose BINDING ENDPOINT points at the automation_gateway adapter or the
+     agmanager app — REST-bound dropdowns AND non-dropdown fields alike. Matched on endpoint URL
+     only, never the request body (a /configuration_manager/... field filtering by adapterType is
+     Configuration Manager, NOT Gateway4). Only forms belonging to IN-SCOPE projects are scanned. -->
+{{#each form}}- **{{form_name}}** — {{field_key}} (`{{bound_endpoint}}`): rebind to the Gateway5/replacement endpoint — returns no data once Gateway4 is removed.
 {{/each}}
-<!-- if none: --> {{none_forms}}  <!-- "No IAG4-bound form fields." -->
+<!-- if none: --> {{none_forms}}  <!-- "No Gateway4-bound form fields." -->
 
 ## Scripts, Playbooks & Roles
 
 {{#each asset}}- `{{filename}}` ({{asset_type}}) — {{short_recommendation}}
 {{/each}}
-<!-- if none: --> {{none_assets}}  <!-- "No IAG4 references found." -->
+<!-- if none: --> {{none_assets}}  <!-- "No Gateway4 references found." -->
 
 ## Inventory
 
+<!-- Two parts:
+     1. Config Manager devices — from analysis.json.devices:
+        - present:true, n_iag4>0 → a lead line "**{n_iag4} of {n_devices}** Config Manager devices are
+          sourced from a Gateway4 adapter (origin `{origins}`) and need to be re-homed in Inventory
+          Manager before Gateway4 is removed:" then ONE dot-separated line of `device_name` values
+          (NOT one bullet per device — that lives in the checklist). If origins vary, state per-device
+          origin inline instead.
+        - present:true, n_iag4==0 → "No Config Manager devices are sourced from a Gateway4 adapter."
+        - present:false → "Config Manager devices not pulled — cannot check device origins."
+          (scoped/local runs where the device check is out of scope → "Skipped — outside scan scope.")
+     2. Gateway4 built-in inventory (from the Gateway4 source the user gave; never Gateway5): if not
+        accessed/none provided → "No Gateway4 built-in inventory was found in the local directory
+        provided." (or the generic not-accessed line); if present → note to move it to Inventory Manager. -->
 {{inventory_finding}}
-<!-- Two parts, both one line each:
-     1. Config Manager devices: if analysis.json devices.present is true, state how many of
-        n_devices have an IAG4 gateway origin and list each flagged device as:
-          - `{{device_name}}` (origin {{origins}}) — device sourced from an IAG4 gateway adapter; re-home it in Inventory Manager before removing IAG4
-        If devices.present is false: "Config Manager devices not pulled — cannot check device origins."
-        If present but n_iag4 == 0: "No Config Manager devices are sourced from an IAG4 gateway."
-     2. Gateway built-in inventory: if IAG4 was not accessed: "IAG4 not accessed — if the gateway
-        holds a built-in inventory, move it to Inventory Manager in IAP." If present: same action.
-        If none: "No IAG4 built-in inventory found." -->
 
 ## Recommended Repository Structure
 
@@ -117,7 +187,7 @@ is NOT project membership — those are Global. Never emit "name unavailable".
      domain in B/C) — never assume real team names. Keep the three option headings and the Naming
      Conventions table headings verbatim so runs stay comparable. Do NOT add a "See /iag …" line
      here — that pointer lives in the SKILL, not the report. -->
-IAG5 runs services **only from a git repository**. Three layouts are shown below; **Option A
+Gateway5 runs services **only from a git repository**. Three layouts are shown below; **Option A
 (mono-repo) is recommended** for most environments — Options B and C are for larger teams or
 stricter ownership / separation-of-concerns requirements. Team names below are placeholders
 (`team1`, `team2`, …) — substitute your own.
@@ -145,17 +215,17 @@ stricter ownership / separation-of-concerns requirements. Team names below are p
 
 ## Manual Action Checklist
 
-<!-- Grouped by item type. Emit a `### <group>` subheading then its `- [ ]` items. Render ONLY the
-     groups that have actions; drop an empty group entirely (do not print an empty heading). Group
-     order is fixed: Workflows, JSON Forms, Scripts/Playbooks/Roles, Inventory, General.
-     - Workflows      ← checklist.workflows: `- [ ] `{{key}}` ({{app}}, {{count}} tasks) — {{recommendation}}`
-     - JSON Forms     ← checklist.forms: `- [ ] **{{form_name}}** — {{field_key}} (`{{bound_endpoint}}`): {{recommendation}}`
-     - Scripts/Playbooks/Roles ← Step 4 assets: `- [ ] `{{filename}}` — {{short_recommendation}}`
-     - Inventory      ← flagged devices (Step 5a) + gateway built-in inventory (Step 5b)
-     - General        ← cross-cutting items -->
+<!-- Grouped by item type. Emit a `### <group>` subheading then its items. Render ONLY groups that
+     have actions; drop an empty group entirely. Group order: Workflows, JSON Forms,
+     Scripts/Playbooks/Roles, Inventory, General. -->
 ### Workflows
 
-{{#each checklist.workflows}}- [ ] `{{key}}` ({{app}}, {{count}} tasks) — {{recommendation}}
+<!-- Self-contained items — each carries its full recommendation text, so no separate legend is
+     needed. checklist.workflows is already sorted by recommendation then name (so identical
+     recommendations sit together). Item: "- [ ] `{{key}}` ({{app_display}}, {{count}} task|tasks) —
+     {{recommendation}}". app_display is "AG Manager" or the adapter type (resolved in analysis.json).
+     Pluralize: "task" if count==1 else "tasks". No codes, no divergence note. -->
+{{#each checklist.workflows}}- [ ] `{{key}}` ({{app_display}}, {{count}} task(s)) — {{recommendation}}
 {{/each}}
 
 ### JSON Forms
@@ -175,10 +245,14 @@ stricter ownership / separation-of-concerns requirements. Team names below are p
 
 ### General
 
-{{#each general_action}}- [ ] {{action_text}}
-{{/each}}
-<!-- General MUST include a repo-setup item pointing at the Recommended Repository Structure
-     section ABOVE, e.g. "- [ ] Set up the IAG5 service git repository — see Recommended Repository
-     Structure above (Option A recommended)" plus a git-secret item. Do NOT emit the old
-     "TBD: git repo layout" line, and do NOT print any service counts. -->
+<!-- Cross-cutting items. MUST include a repo-setup item pointing at the Recommended Repository
+     Structure section and a git-secret item. THEN, if analysis.json.unresolved_children is non-empty,
+     render the moved data-gap list here as its own labelled block (this is where the top callout
+     points). Do NOT emit any service counts. -->
+- [ ] Set up the Gateway5 service git repository — see [Recommended Repository Structure](#recommended-repository-structure) (Option A recommended)
+- [ ] Store Gateway5 service credentials as git-backed secrets, not embedded in scripts
 
+**Unresolved child workflows — pull into scope (live) or add JSON to `--local-dir`, then re-run:**
+
+{{#each unresolved_children}}- [ ] `{{name}}`
+{{/each}}

--- a/helpers/iag-migration/readiness-report-template.md
+++ b/helpers/iag-migration/readiness-report-template.md
@@ -8,22 +8,25 @@ The checklist is LAST. The TOC links to each section.
 Placeholders are wrapped in {{ }}. Every section is ALWAYS rendered — if a section has no
 findings, emit its "No Gateway4 references found." line instead of dropping the section.
 
-DESIGN: the ANALYSIS sections (Workflows, JSON Forms, Inventory) are PURE FACTS — what is on the
-platform, nothing inferred, nothing recommended. No per-task "what to do", no remediation codes, no
-legend. The only forward-looking / suggested content lives in the two clearly-labelled sections at
-the END — Recommended Repository Structure and Manual Action Checklist. Never move recommendation
-text into the analysis tables.
+DESIGN: the analysis stays factual, but each Gateway4 task carries ONE short remediation CODE
+(WRAP / REVIEW / ARGS / INV). The codes are explained ONCE in the static "Recommended Actions"
+legend section; task tables show only the code, never the full sentence. The full recommendation
+text lives in the legend and the end Manual Action Checklist. Codes are a best-effort classification
+from each task's name/summary/description — the legend says "review each". Never write the full
+recommendation sentence into the Workflows tables (just the code).
 
 WORDING RULE (hard): the rendered report must NOT contain "iag", "IAG4", or "IAG5". Use
 "Itential Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5". Keep literal API/app names
 (GatewayManager.runService, AG Manager) and the ACTUAL adapter names verbatim so the reader can
 identify them on the platform. (Scripts/variable names may still use IAG internally — never rendered.)
 
-FIXED recommendation strings — used ONLY in the end checklist / repo section, NEVER the analysis.
-They are the VERBATIM REC_* constants in analyze_iag4.py; keep both in sync (determinism contract):
-  - self-management task:   move to the Inventory Manager application; drop this task
-  - python-script task:     re-implement as a Gateway5 python-script service; call via GatewayManager.runService
-  - ansible-playbook task:  register playbook as a Gateway5 ansible-playbook service; call via GatewayManager.runService
+FIXED remediation CODES — the "Recommended action" cell for each is the VERBATIM REC_* constant in
+analyze_iag4.py (CODE_BY_TYPE / REC_BY_CODE); keep both in sync (determinism contract):
+  - WRAP   (collection-or-role task): wrap in a Python script (preferred) or an Ansible playbook; run as a Gateway5 service
+  - REVIEW (ansible playbook):        likely no code change — review how inventory is handled (Gateway5 has no built-in inventory)
+  - ARGS   (python script):           change positional args to named args (--flag / argparse); run as a Gateway5 python-script service
+  - INV    (device/group op on the Gateway4 adapter): move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation
+Other fixed strings (keep in sync too):
   - json form field:        rebind to the Gateway5/replacement endpoint — returns no data once Gateway4 is removed.
   - gateway4-origin device:  device sourced from a Gateway4 adapter; re-home it in Inventory Manager before removing Gateway4
   - python asset (argv):    convert positional args to argparse flags; place in a git repo
@@ -33,8 +36,9 @@ They are the VERBATIM REC_* constants in analyze_iag4.py; keep both in sync (det
   - playbook asset:         place in a git repo; no code change
 
 Sort rules (analyze_iag4.py already applies them — render straight through): workflows by name (asc),
-then project id, then workflow id; tasks within a workflow by task id (asc); checklist by
-recommendation then name; forms by name; assets by filename; devices by name; unresolved_children as
+then project id, then workflow id; tasks within a workflow by task id (asc); checklist by code
+(WRAP, REVIEW, ARGS, INV) then name; forms by name; assets by filename; devices by name;
+unresolved_children as
 given (sorted). No per-row timestamps.
 
 Workflow location comes from the workflow's `namespace` field (authoritative project membership):
@@ -65,12 +69,13 @@ SAME way everywhere (index Scope/Connector column AND detail heading) — the pr
 ## Contents
 
 1. [Summary](#summary)
-2. [Workflows](#workflows)
-3. [JSON Forms](#json-forms)
-4. [Scripts, Playbooks & Roles](#scripts-playbooks--roles)
-5. [Inventory](#inventory)
-6. [Recommended Repository Structure](#recommended-repository-structure)
-7. [Manual Action Checklist](#manual-action-checklist)
+2. [Recommended Actions](#recommended-actions)
+3. [Workflows](#workflows)
+4. [JSON Forms](#json-forms)
+5. [Scripts, Playbooks & Roles](#scripts-playbooks--roles)
+6. [Inventory](#inventory)
+7. [Recommended Repository Structure](#recommended-repository-structure)
+8. [Manual Action Checklist](#manual-action-checklist)
 
 ## Summary
 
@@ -84,10 +89,25 @@ SAME way everywhere (index Scope/Connector column AND detail heading) — the pr
 | Referenced workflows not analyzed (unresolved) | {{n_unresolved}} |
 | Gateway4 inventory | {{inventory_status}} |
 
+## Recommended Actions
+
+<!-- STATIC legend, always rendered verbatim. The "Recommended action" cells are the VERBATIM
+     REC_WRAP / REC_REVIEW / REC_ARGS / REC_INV constants from analyze_iag4.py — do not reword
+     (determinism sync). Each Gateway4 task in Workflows is tagged with one of these codes. -->
+Each Gateway4 task in the Workflows section is tagged with one short code. Codes are a best-effort
+classification from the task's name and description — **review each** before acting.
+
+| Code | Applies to (Gateway4 task type) | Recommended action |
+|---|---|---|
+| **WRAP** | Ansible collection-module task or role | wrap in a Python script (preferred) or an Ansible playbook; run as a Gateway5 service |
+| **REVIEW** | Ansible playbook | likely no code change — review how inventory is handled (Gateway5 has no built-in inventory) |
+| **ARGS** | Python script | change positional args to named args (--flag / argparse); run as a Gateway5 python-script service |
+| **INV** | Device/group operation on the Gateway4 adapter | move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation |
+
 ## Workflows
 
-<!-- PURE-FACTS analysis section — NO recommendations, NO codes, NO "what to do". Just what is on the
-     platform. GROUPED BY LOCATION: iterate analysis.json.workflow_groups (already ordered — projects
+<!-- Facts + a short remediation CODE per task (Rec column; full text is in the Recommended Actions
+     legend). GROUPED BY LOCATION: iterate analysis.json.workflow_groups (already ordered — projects
      first by name, then a final "Global" group; workflows within a group already name-sorted). Do
      NOT recompute or re-sort.
 
@@ -98,20 +118,23 @@ SAME way everywhere (index Scope/Connector column AND detail heading) — the pr
          per-workflow rows below (no "Scope / Connector" column, no location in the detail heading).
 
        an INDEX TABLE for that group's workflows (project context is the headline, so it's dropped):
-         | Workflow | Tasks | Interface(s) | ID |
-         | `{{workflow_name}}` | {{n_tasks}} | {{interfaces joined ", "}} | `{{workflow_id}}` |
+         | Workflow | Tasks | Interface(s) | Rec | ID |
+         | `{{workflow_name}}` | {{n_tasks}} | {{interfaces joined ", "}} | {{codes joined ", "}} | `{{workflow_id}}` |
          - Interface(s) = workflow.interfaces (distinct, task order) joined ", " — FACT from the data:
            "AG Manager" (AGManager application) and/or the ACTUAL adapter name(s); what the reader
-           needs for Gateway5 cluster mapping. No recommendation implied.
+           needs for Gateway5 cluster mapping.
+         - Rec = workflow.codes (distinct codes, CODE_ORDER) joined ", " (e.g. "WRAP, ARGS"). Codes
+           are explained in the Recommended Actions legend above.
          - ALWAYS print `workflow_id` (disambiguates the same use case cloned across places — identical
            names, distinct ids; real distinct workflows, not a pull artifact).
 
        then ONE `####` DETAIL SECTION per workflow in the group:
          #### `{{workflow_name}}` · `{{workflow_id}}`      (no location — the group headline carries it)
-         a 3-col table, ONE ROW PER TASK (facts only):
-           | Task | Name | Interface |
-           | `{{task_id}}` | {{task_name}} | {{interface}} |
-         `interface` (req a) = exactly "AG Manager" or the ACTUAL adapter name (verbatim).
+         a 4-col table, ONE ROW PER TASK:
+           | Task | Name | Interface | Rec |
+           | `{{task_id}}` | {{task_name}} | {{interface}} | {{code}} |
+         `interface` (req a) = exactly "AG Manager" or the ACTUAL adapter name (verbatim). `code` =
+         the task's short remediation code (WRAP / REVIEW / ARGS / INV) — full text in the legend.
 
          References — collect the relationship lines for this workflow, in this order:
             (1) if called_by (req c) non-empty: "Called by `{{name}}` (`{{id}}`), `{{name}}` (`{{id}}`)"
@@ -120,22 +143,22 @@ SAME way everywhere (index Scope/Connector column AND detail heading) — the pr
                 "`{{task_id}}` output used by `{{ref_id}}`, `{{ref_id}}`"
            Zero lines → render nothing. Exactly ONE line → inline "**References:** <line>". MORE than
            one → a "**References:**" header then a bullet per line. -->
-{{n_workflows}} workflows reference Gateway4 tasks ({{n_gw4_tasks}} tasks total), grouped by project below (Global workflows last). Each project lists its workflows, then per-workflow task detail and cross-references.
+{{n_workflows}} workflows reference Gateway4 tasks ({{n_gw4_tasks}} tasks total), grouped by project below (Global workflows last). Each project lists its workflows, then per-workflow task detail and cross-references. The **Rec** column codes are explained in [Recommended Actions](#recommended-actions).
 
 {{#each group}}
 ### {{group.label}}
 
-| Workflow | Tasks | Interface(s) | ID |
-|---|---|---|---|
-{{#each group.workflow}}| `{{workflow_name}}` | {{n_tasks}} | {{interfaces}} | `{{workflow_id}}` |
+| Workflow | Tasks | Interface(s) | Rec | ID |
+|---|---|---|---|---|
+{{#each group.workflow}}| `{{workflow_name}}` | {{n_tasks}} | {{interfaces}} | {{codes}} | `{{workflow_id}}` |
 {{/each}}
 
 {{#each group.workflow}}
 #### `{{workflow_name}}` · `{{workflow_id}}`
 
-| Task | Name | Interface |
-|---|---|---|
-{{#each task}}| `{{task_id}}` | {{task_name}} | {{interface}} |
+| Task | Name | Interface | Rec |
+|---|---|---|---|
+{{#each task}}| `{{task_id}}` | {{task_name}} | {{interface}} | {{code}} |
 {{/each}}
 {{references_block}}
 {{/each}}

--- a/helpers/iag-migration/readiness-report-template.md
+++ b/helpers/iag-migration/readiness-report-template.md
@@ -1,0 +1,184 @@
+<!--
+IAG4 → IAG5 Readiness Report — FIXED TEMPLATE.
+The iag4-to-iag5 skill fills this in. Keep section order and headings identical every run so
+the same inputs always produce a byte-identical report (aside from the header metadata line).
+Canonical section order (also the Table of Contents at the top): Summary, Workflows, JSON Forms,
+Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure, Manual Action Checklist.
+The checklist is LAST (after Recommended Repository Structure). The TOC links to each section.
+Placeholders are wrapped in {{ }}. Every section is ALWAYS rendered — if a section has no
+findings, emit its "No IAG4 references found." line instead of dropping the section.
+Sort rules: workflows by name (asc), then project id, then workflow id; tasks within a workflow by task id (asc),
+forms by name (asc), IAG4 assets by filename (asc), devices by name (asc), checklist by section
+then name. No per-row timestamps. The script (analyze_iag4.py) already applies every sort — render
+straight from analysis.json.
+Keep it terse — this is a working checklist, not a narrative. No read-only banners, no "two
+rules" preamble, no per-workflow tables. Those belong in the skill, not the report.
+Short recommendation strings are FIXED (verbatim) for determinism — they are the module-level
+constants in analyze_iag4.py; keep both in sync:
+  - ansible-playbook task:  register playbook as an IAG5 ansible-playbook service; call via GatewayManager.runService
+  - python-script task:     re-implement as an IAG5 python-script service; call via GatewayManager.runService
+  - self-management task:   move to the Inventory Manager application; drop this task
+  - json form field:        rebind to the IAG5/replacement endpoint — returns no data once IAG4 is removed.
+  - iag4-origin device:     device sourced from an IAG4 gateway adapter; re-home it in Inventory Manager before removing IAG4
+  - python asset (argv):    convert positional args to argparse flags; place in a git repo
+  - python asset (argparse):already uses named args; place in a git repo
+  - shell asset:            wrap in a Python script (python-script service) or register as an executable service; place in a git repo
+  - role asset:             wrap in a playbook or Python script; place in a git repo
+  - playbook asset:         place in a git repo; no code change
+Workflow location comes from the workflow's `namespace` field (authoritative project membership):
+"Global" when not project-owned, else "«{project_name}» ({project_id})". A stale @id: name prefix
+is NOT project membership — those are Global. Never emit "name unavailable".
+-->
+
+# IAG4 → IAG5 Migration Readiness
+
+**Generated:** {{YYYY-MM-DD}} · **Working dir:** {{working_dir}}
+**IAP source:** {{iap_source}} · **IAG4 assets:** {{iag4_source}}
+**IAG4 matched:** adapter `{{adapter_type}}` (instances: {{adapter_instances}}), app `{{agmanager_app}}`
+**Scope:** {{scope_description}}
+
+## Contents
+
+1. [Summary](#summary)
+2. [Workflows](#workflows)
+3. [JSON Forms](#json-forms)
+4. [Scripts, Playbooks & Roles](#scripts-playbooks--roles)
+5. [Inventory](#inventory)
+6. [Recommended Repository Structure](#recommended-repository-structure)
+7. [Manual Action Checklist](#manual-action-checklist)
+
+## Summary
+
+| Metric | Count |
+|---|---|
+| Workflows referencing IAG4 | {{n_workflows}} |
+| IAG4 tasks | {{n_iag4_tasks}} |
+| JSON form fields bound to IAG4 | {{n_forms}} |
+| Config Manager devices sourced from IAG4 | {{n_iag4_devices}} |
+| IAG4 scripts/playbooks/roles (local) | {{n_assets}} |
+| IAG4 inventory | {{inventory_status}} |
+
+## Workflows
+
+<!-- One TABLE, ONE ROW PER WORKFLOW (not per task). All of a workflow's IAG4 tasks go in the last
+     cell, one per line, joined by literal <br>. This keeps each workflow on a single row so a
+     reader can instantly see which workflows have >1 IAG4 task, even when several workflows share
+     the same NAME (the same use case cloned across places) — `workflow_id` is what distinguishes
+     them; they are distinct workflows, not a pull artifact. Location is the project NAME when the
+     workflow's `namespace` marks it as project-owned (project id in parens for disambiguation);
+     when `location_type` is "global" (no live project — includes workflows whose name carries a
+     stale @id: prefix for a deleted project) Location is exactly "Global". Never emit "name
+     unavailable". Rows sorted by workflow name, then project id, then workflow id; tasks within the
+     cell by task id (the script already applies this — render straight through). -->
+| Workflow | Workflow ID | Location | IAG4 Tasks & Recommendations |
+|---|---|---|---|
+{{#each workflow}}| {{workflow_name}} | `{{workflow_id}}` | {{location}} | {{#join task with <br>}}`{{task_id}}` **{{task_name}}** — {{short_recommendation}}{{/join}} |
+{{/each}}
+<!-- location cell: "Global", or "«{project_name}» ({project_id})" when location_type == "project".
+     tasks cell: for each task `{{task_id}}` **{{task_name}}** — {{short_recommendation}}, joined by <br>. -->
+<!-- if none: --> {{none_workflows}}  <!-- "No IAG4 references found." -->
+
+## JSON Forms
+
+<!-- Any form field whose endpoint/body/validation points at the automation_gateway adapter or the
+     agmanager app — REST-bound dropdowns AND non-dropdown fields alike. -->
+{{#each form}}- **{{form_name}}** — {{field_key}} (`{{bound_endpoint}}`): rebind to the IAG5/replacement endpoint — returns no data once IAG4 is removed.
+{{/each}}
+<!-- if none: --> {{none_forms}}  <!-- "No IAG4-bound form fields." -->
+
+## Scripts, Playbooks & Roles
+
+{{#each asset}}- `{{filename}}` ({{asset_type}}) — {{short_recommendation}}
+{{/each}}
+<!-- if none: --> {{none_assets}}  <!-- "No IAG4 references found." -->
+
+## Inventory
+
+{{inventory_finding}}
+<!-- Two parts, both one line each:
+     1. Config Manager devices: if analysis.json devices.present is true, state how many of
+        n_devices have an IAG4 gateway origin and list each flagged device as:
+          - `{{device_name}}` (origin {{origins}}) — device sourced from an IAG4 gateway adapter; re-home it in Inventory Manager before removing IAG4
+        If devices.present is false: "Config Manager devices not pulled — cannot check device origins."
+        If present but n_iag4 == 0: "No Config Manager devices are sourced from an IAG4 gateway."
+     2. Gateway built-in inventory: if IAG4 was not accessed: "IAG4 not accessed — if the gateway
+        holds a built-in inventory, move it to Inventory Manager in IAP." If present: same action.
+        If none: "No IAG4 built-in inventory found." -->
+
+## Recommended Repository Structure
+
+<!-- FIXED guidance section, always rendered. **Option A is ALWAYS the recommendation** — never
+     make it conditional on service count, and do NOT print any service counts here. Tailor the
+     Option A tree and the Naming-Conventions "Examples" column to THIS environment's migrated
+     services (from checklist.workflows + the Step 4 assets): one leaf per service, foldered by
+     domain, annotated `← was <original> (<iag4_type>)`. python-script leaves get main.py +
+     requirements.txt; ansible-playbook leaves get playbook.yml. Options B and C are shown for
+     scale but keep them brief. Use placeholder team names `team1`, `team2`, … (one team per
+     domain in B/C) — never assume real team names. Keep the three option headings and the Naming
+     Conventions table headings verbatim so runs stay comparable. Do NOT add a "See /iag …" line
+     here — that pointer lives in the SKILL, not the report. -->
+IAG5 runs services **only from a git repository**. Three layouts are shown below; **Option A
+(mono-repo) is recommended** for most environments — Options B and C are for larger teams or
+stricter ownership / separation-of-concerns requirements. Team names below are placeholders
+(`team1`, `team2`, …) — substitute your own.
+
+### Option A — Mono-repo (recommended)
+
+{{option_a_tree}}
+
+### Option B — Multi-repo (per-domain ownership)
+
+{{option_b_tree}}
+
+### Option C — Service-file repo + code repos (separation of concerns)
+
+{{option_c_tree}}
+
+### Naming Conventions
+
+| Item | Pattern | Examples (this environment) |
+|---|---|---|
+| Services | `{team}-{domain}-{action}` | {{service_name_examples}} |
+| Decorators | `{service-name}-decorator` | {{decorator_examples}} |
+| Repositories | `{team}-{purpose}` | {{repo_examples}} |
+| Secrets | `{team}-{system}-{purpose}` | {{secret_examples}} |
+
+## Manual Action Checklist
+
+<!-- Grouped by item type. Emit a `### <group>` subheading then its `- [ ]` items. Render ONLY the
+     groups that have actions; drop an empty group entirely (do not print an empty heading). Group
+     order is fixed: Workflows, JSON Forms, Scripts/Playbooks/Roles, Inventory, General.
+     - Workflows      ← checklist.workflows: `- [ ] `{{key}}` ({{app}}, {{count}} tasks) — {{recommendation}}`
+     - JSON Forms     ← checklist.forms: `- [ ] **{{form_name}}** — {{field_key}} (`{{bound_endpoint}}`): {{recommendation}}`
+     - Scripts/Playbooks/Roles ← Step 4 assets: `- [ ] `{{filename}}` — {{short_recommendation}}`
+     - Inventory      ← flagged devices (Step 5a) + gateway built-in inventory (Step 5b)
+     - General        ← cross-cutting items -->
+### Workflows
+
+{{#each checklist.workflows}}- [ ] `{{key}}` ({{app}}, {{count}} tasks) — {{recommendation}}
+{{/each}}
+
+### JSON Forms
+
+{{#each checklist.forms}}- [ ] **{{form_name}}** — {{field_key}} (`{{bound_endpoint}}`): {{recommendation}}
+{{/each}}
+
+### Scripts, Playbooks & Roles
+
+{{#each asset}}- [ ] `{{filename}}` — {{short_recommendation}}
+{{/each}}
+
+### Inventory
+
+{{#each device}}- [ ] `{{device_name}}` (origin {{origins}}) — {{recommendation}}
+{{/each}}{{inventory_action}}
+
+### General
+
+{{#each general_action}}- [ ] {{action_text}}
+{{/each}}
+<!-- General MUST include a repo-setup item pointing at the Recommended Repository Structure
+     section ABOVE, e.g. "- [ ] Set up the IAG5 service git repository — see Recommended Repository
+     Structure above (Option A recommended)" plus a git-secret item. Do NOT emit the old
+     "TBD: git repo layout" line, and do NOT print any service counts. -->
+


### PR DESCRIPTION
## What this adds

A new `/iag4-to-iag5` skill that analyzes Itential platform assets to move from Automation Gateway 4 to Gateway 5.

## Motivation

Gateway4 and Gateway5 are architecturally different. Before migrating, engineers need to know exactly what on the platform is using IAG4 — workflows, JSON forms, scripts, playbooks, roles, and inventory. This skill surfaces all of that in one deterministic report.

## What it does
- Scans all workflows (in and out of projects) + JSON forms for IAG4 task references (`AGManager` / `automation_gateway`)
- Runs `analyze_iag4.py` — a deterministic Python script — to classify findings and produce stable, sorted JSON (same inputs = identical output)
- Scans local IAG4 assets (Python scripts, Ansible playbooks, roles) if a gateway path is provided
- Checks Configuration Manager for devices sourced from IAG4 gateways
- Produces `<working-dir>/iag4-to-iag5-readiness.md` — a terse Markdown checklist the engineer works through manually

**It's a read-only skill against the platform — no creates, updates, or deletes. It identifies and recommends; it does not rewrite scripts, generate IAG5 service YAML, or rewire workflows. For building IAG5 services, use `/iag`.**

## Files changed

| File | Change |
|------|--------|
| `.claude/skills/iag4-to-iag5/SKILL.md` | New skill |
| `helpers/iag-migration/analyze_iag4.py` | Deterministic analysis script |
| `helpers/iag-migration/readiness-report-template.md` | Fixed report template |
| `AGENTS.md` | Skill router entry |
| `README.md` | Platform skills table entry |

## To Test
Create a working directory and place .env file in it with your connection information to an IAP instance, you may also add your current IAG4 assets into that directory then run a prompt "Am I ready for Gateway5?" or "Use /iag4-to-iag5 to analyze my environment"