### PR TITLE
chore(iag4-to-iag5): improve report clarity and correct remediation recommendation

### DIFF
--- a/.claude/skills/iag4-to-iag5/SKILL.md
+++ b/.claude/skills/iag4-to-iag5/SKILL.md
@@ -344,6 +344,9 @@ Then **read `tmp/analysis.json`** — it contains `identifiers` (now incl. `adap
   childJob. Only in-scope parents ever appear (rule 3).
 - **`unresolved_children`** / **`warnings`** — referenced workflows that could not be read. Surface,
   never fabricate their contents (rule 2).
+- **`workflow_groups[].n_workflows`** / **`n_tasks`** — per-group aggregate counts (workflow count
+  and total Gateway4 task count in that project/Global group). Drives the new Workflows Summary
+  table at the top of the Workflows section — render, do not recompute.
 
 **What the script does (documented here so the report strings stay reviewable — the script is the
 source of truth; do NOT hand-classify):**
@@ -353,11 +356,12 @@ adapter (type `AutomationGateway`, or a resolved instance id) or the `AGManager`
 flags `GatewayManager` (IAG5). Each IAG4 task is classified from its name/summary/description into
 exactly one row, with the verbatim recommendation the report prints:
 
-| Detected IAG4 task | `iag4_type` label | Short recommendation (verbatim) |
-|---|---|---|
-| **Device/group self-management** (add/remove/create/delete device(s) or group) — checked first | `self-management` | move to the Inventory Manager application; drop this task |
-| Playbook/role op — name/summary/description contains "playbook" or "role" (e.g. `install_remove_inactive`, `transfer_image`) | `ansible-playbook` | register playbook as a Gateway5 ansible-playbook service; call via GatewayManager.runService |
-| **Everything else** — any other IAG4 op (`itential_cli`, `isAlive`, `runCommand`, `getDeviceConfig`, …) | `python-script` | re-implement as a Gateway5 python-script service; call via GatewayManager.runService |
+| Detected IAG4 task | `iag4_type` label | Code | Short recommendation (verbatim) |
+|---|---|---|---|
+| **Device/group self-management** (add/remove/create/delete device(s) or group) — checked first | `self-management` | `INV` | move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation |
+| Playbook op — name/summary/description contains "playbook" | `ansible-playbook` | `REVIEW` | likely no code change — review how inventory is handled (Gateway5 has no built-in inventory) |
+| Ansible collection-module task or role — name/summary/description contains "role"/"collection", or the task name is an FQCN (e.g. `cisco.ios_ios_command`); this is where `itential_cli`/`itential_set_config` land (their description is "Ansible Role") | `collection-or-role` | `WRAP` | wrap in a Python script or an Ansible playbook and run as a Gateway5 service, or replace with an Inventory Manager send_command/set_config task if that covers the same logic |
+| **Everything else** — any other IAG4 op (`isAlive`, `runCommand`, `getDeviceConfig`, …) | `python-script` | `ARGS` | change positional args to named args (--flag / argparse); run as a Gateway5 python-script service |
 
 *Interface, references, closure (the script also computes these — render, don't recompute):*
 - **Interface (req a):** each Gateway4 task is tagged `interface` = `"AG Manager"` when it uses the
@@ -381,7 +385,8 @@ by parsing the `@<id>:` name prefix. A workflow is **in a project** (and the rep
 project name) iff `namespace` marks it project-owned; otherwise it is **Global** — including
 workflows whose name still carries a stale `@<id>:` prefix pointing at a deleted project (a bulk-
 import leftover, not live membership). Each entry carries `location_type` (`global`/`project`),
-`project_id`, `project_name`. Render location as `«name» (id)` for a project, else `Global`.
+`project_id`, `project_name`. Render location as plain `name (id)` for a project, else `Global`
+(no special quoting/brackets around the name).
 **Never emit "name unavailable"** — the old projects.json-prefix lookup produced that; `namespace`
 does not. (`projects.json` is now only a defensive fallback for the rare workflow missing a
 namespace whose prefix still resolves to a live project.) Also note `workflow_id` — it
@@ -471,7 +476,17 @@ Actions, Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory, Recommende
 Structure, Manual Action Checklist** — the checklist is **last**, after the repo section. Immediately
 under the header table, emit a `## Contents` table-of-contents with one linked entry per section
 (GitHub-style anchors, e.g. `[Scripts, Playbooks & Roles](#scripts-playbooks--roles)`) so the reader
-can jump around.
+can jump around. **Nest the Workflows entry** with one sub-link per `workflow_groups[]` entry
+(project/Global groups, same order as rendered), e.g.:
+```
+3. [Workflows](#workflows)
+   - [Arista EOS (66d0da1721161b4df27174d0)](#arista-eos-66d0da1721161b4df27174d0)
+   - [Global](#global)
+```
+Anchor = a plain GitHub slug of `group.label`: lowercase, drop any character that isn't a
+letter/digit/space/hyphen (drops the parentheses), then spaces → hyphens. Do **not** nest down to
+individual workflows — that would make the TOC unreadably long; the group's own index table already
+lists each workflow with its ID.
 
 **WORDING — the rendered report must NOT contain "iag"/"IAG4"/"IAG5" (req d).** Use "Itential
 Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5". Keep literal API/app names
@@ -499,9 +514,15 @@ part of the file's content). If it matches, fix the wording before telling the u
 - **Workflows** section ← `workflow_groups[]` (already ordered). **Grouped by location**: iterate
   `workflow_groups` (projects first by name, then a final `Global` group; workflows within each
   already name-sorted). Do NOT re-sort.
-  - **Group headline** — `### {group.label}` where `label` is `«project_name» (project_id)` for a
-    project or `Global`. The project/Global identity lives HERE, so it is **not** repeated below
-    (no "Scope / Connector" column, no location in the detail heading — kills the repeated text).
+  - **Workflows Summary table** — render FIRST, right after the intro line and before the per-group
+    breakdown: one row per group, `Project / Location | Workflows | Tasks to fix` =
+    `` {group.label} | {group.n_workflows} | {group.n_tasks} ``, plus a final `**Total**` row from
+    `counts.n_workflows` / `counts.n_iag4_tasks`. Straight from the analyzer's per-group aggregates —
+    do not recompute.
+  - **Group headline** — `### {group.label}` where `label` is plain `project_name (project_id)` for a
+    project or `Global` (no special quoting/brackets around the name). The project/Global identity
+    lives HERE, so it is **not** repeated below (no "Scope / Connector" column, no location in the
+    detail heading — kills the repeated text).
   - **Per-group index table** — one row per workflow: `Workflow | Tasks | Interface(s) | Rec | ID` =
     `` `workflow_name` | n_tasks | interfaces | codes | `workflow_id` ``. `interfaces` ← distinct
     `interfaces` (task order) — factual `AG Manager` and/or adapter name(s), for cluster mapping.
@@ -543,13 +564,17 @@ part of the file's content). If it matches, fix the wording before telling the u
 - **Manual Action Checklist** — the **last** section — **grouped by item type**, each group under its
   own `###` subheading, in fixed order: **Workflows, JSON Forms, Scripts/Playbooks & Roles, Inventory,
   General**. **Render only groups that have items — drop an empty group entirely.**
-  - **Workflows** ← `checklist.workflows` (already sorted by code then name — WRAP, REVIEW, ARGS, INV
-    — so same-recommendation items cluster). Each item is **self-contained** — it carries its own
-    recommendation text: `` - [ ] `key` (app_display, N task/tasks) — recommendation ``. Use
-    `app_display` (already `AG Manager` or the adapter type) and pluralize `task`/`tasks` on `count`.
+  - **Workflows** ← `checklist.workflows` (already `{code, workflow_name, workflow_id, count}` sorted
+    by code (WRAP, REVIEW, ARGS, INV) then workflow name/id). Grouped **by code**: render one `####`
+    heading per code that has items — `#### {code} — {REC_BY_CODE[code]}` (the recommendation text
+    appears ONCE per code heading, not per item) — then one line per workflow underneath: `` - [ ]
+    `workflow_name` (`workflow_id`) — N task(s) ``. Skip a code heading entirely if it has no items.
+    This tells the reader WHICH workflow needs the work, not just an environment-wide task-name total.
   - **JSON Forms** ← `checklist.forms`. **Scripts, Playbooks & Roles** ← the Step 4 assets.
-  - **Inventory** ← flagged devices from `analysis.json → devices` (one `- [ ]` per device) plus the
-    gateway built-in-inventory action (Step 5b); scoped/local run where devices weren't pulled →
+  - **Inventory** ← flagged devices from `analysis.json → devices` — one `- [ ] \`device_name\` —
+    origin \`origins\`` per device (name + origin only; the re-homing recommendation is stated once,
+    already, in the Inventory report section above — do not repeat it here) plus the gateway
+    built-in-inventory action (Step 5b); scoped/local run where devices weren't pulled →
     "Skipped — outside scan scope."
   - **General** ← cross-cutting items: a repo-setup item linking to the Recommended Repository
     Structure section (`Set up the Gateway5 service git repository — see [Recommended Repository
@@ -565,6 +590,12 @@ sections with no findings get `No Gateway4 references found.`
 
 Finally, tell the user the report path and give a one-paragraph headline of the counts. Note
 that `tmp/` is read-cache/scratch and safe to delete.
+
+**The skill's job ends here.** Once the report is written and its path/headline is given to the
+user, STOP. Do not follow up with next-step suggestions, offers to convert/migrate/build anything,
+or any other proactive recommendation — not even "would you like me to start building the
+repository structure" or "I can convert script X now." If the user wants to act on the report,
+they will say so and start a new, separate request (e.g. `/iag`); this skill never volunteers it.
 
 ---
 
@@ -606,6 +637,9 @@ that `tmp/` is read-cache/scratch and safe to delete.
   `--all` can overflow a small model's context on large platforms.
 - **Identification only.** Do not create Gateway5 services, edit workflows, or rewrite scripts here.
   Route actual builds to `/iag`.
+- **Done means done.** The skill's only deliverable is the report. Once it's written, stop — no
+  follow-up suggestions, no offering to convert scripts, build the repo, or do anything else
+  automatically, even if it seems helpful. Let the user initiate any next step explicitly.
 
 ## See also
 - `/iag` — building IAG5 service(s) (Python/Ansible/OpenTofu), service YAML, `runService` wiring.

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Spec-driven infrastructure automation and orchestration — delivered by AI agen
 ## Table of Contents
 
 - [Itential — Agentic Builder Skills](#itential--agentic-builder-skills)
-  - [Table of Contents](#table-of-contents)
-  - [Prerequisites](#prerequisites)
-  - [Getting Started](#getting-started)
-  - [How to Use It](#how-to-use-it)
-  - [Skills](#skills)
-  - [Spec Library](#spec-library)
-  - [Demo Specs](#demo-specs)
-  - [Docs](#docs)
-  - [Contributing](#contributing)
-  - [Support](#support)
-  - [License](#license)
+- [Table of Contents](#table-of-contents)
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+- [How to Use It](#how-to-use-it)
+- [Skills](#skills)
+- [Spec Library](#spec-library)
+- [Demo Specs](#demo-specs)
+- [Docs](#docs)
+- [Contributing](#contributing)
+- [Support](#support)
+- [License](#license)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Spec-driven infrastructure automation and orchestration — delivered by AI agen
 ## Table of Contents
 
 - [Itential — Agentic Builder Skills](#itential--agentic-builder-skills)
-- [Table of Contents](#table-of-contents)
-- [Prerequisites](#prerequisites)
-- [Getting Started](#getting-started)
-- [How to Use It](#how-to-use-it)
-- [Skills](#skills)
-- [Spec Library](#spec-library)
-- [Demo Specs](#demo-specs)
-- [Docs](#docs)
-- [Contributing](#contributing)
-- [Support](#support)
-- [License](#license)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Getting Started](#getting-started)
+  - [How to Use It](#how-to-use-it)
+  - [Skills](#skills)
+  - [Spec Library](#spec-library)
+  - [Demo Specs](#demo-specs)
+  - [Docs](#docs)
+  - [Contributing](#contributing)
+  - [Support](#support)
+  - [License](#license)
 
 ---
 

--- a/helpers/iag-migration/analyze_iag4.py
+++ b/helpers/iag-migration/analyze_iag4.py
@@ -34,7 +34,7 @@ sys.dont_write_bytecode = True
 # Each Gateway4 workflow task gets ONE short CODE + a recommendation. The codes are defined once in
 # the report's "Recommended Actions" legend; task tables show only the code. Codes/recs are a
 # best-effort classification from the task's name/summary/description — the legend says "review each".
-REC_WRAP = "wrap in a Python script (preferred) or an Ansible playbook; run as a Gateway5 service"
+REC_WRAP = "wrap in a Python script or an Ansible playbook and run as a Gateway5 service, or replace with an Inventory Manager send_command/set_config task if that covers the same logic"
 REC_REVIEW = "likely no code change — review how inventory is handled (Gateway5 has no built-in inventory)"
 REC_ARGS = "change positional args to named args (--flag / argparse); run as a Gateway5 python-script service"
 REC_INV = "move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation"
@@ -147,6 +147,9 @@ def classify(task):
       2. ansible playbook                                -> ansible-playbook / REVIEW
       3. ansible collection-module task or role          -> collection-or-role / WRAP
       4. everything else (treated as a python script)    -> python-script / ARGS
+
+    e.g. itential_cli/itential_set_config are Ansible roles -> WRAP (wrap in a Python script or
+    Ansible playbook, or use an Inventory Manager send_command/set_config task instead).
     """
     hay = " ".join(str(task.get(k) or "") for k in ("name", "summary", "description", "canvasName"))
     name = task.get("name") or ""
@@ -385,13 +388,15 @@ def scan_workflows(wf_rows, instance_ids, prefixes, scope, project_names):
 def group_workflows(workflows):
     """Group the (already name-sorted) workflows by location so the report can headline each project
     then list its workflows. Deterministic: projects first (by project name, then id), then Global
-    LAST; workflows within a group keep the flat name/id order. Each group carries a `label`
-    («project_name» (project_id) or "Global") and the same workflow dicts (no data change)."""
+    LAST; workflows within a group keep the flat name/id order. Each group carries a plain `label`
+    ("project_name (project_id)" or "Global"), aggregate `n_workflows`/`n_tasks` counts (for the
+    Workflows Summary table — the report renders these, never recomputes them), and the same
+    workflow dicts (no data change)."""
     buckets = {}
     for w in workflows:
         if w["location_type"] == "project":
             key = ("0", w["project_name"] or "", w["project_id"] or "")
-            label = "«%s» (%s)" % (w["project_name"], w["project_id"])
+            label = "%s (%s)" % (w["project_name"], w["project_id"])
         else:
             key = ("1", "", "")
             label = "Global"
@@ -404,7 +409,11 @@ def group_workflows(workflows):
                 "workflows": [],
             }
         buckets[key]["workflows"].append(w)
-    return [buckets[k] for k in sorted(buckets.keys())]
+    groups = [buckets[k] for k in sorted(buckets.keys())]
+    for g in groups:
+        g["n_workflows"] = len(g["workflows"])
+        g["n_tasks"] = sum(len(w["tasks"]) for w in g["workflows"])
+    return groups
 
 
 def _endpoint_urls(field):
@@ -516,25 +525,22 @@ def scan_devices(devices_path, instance_ids):
 
 
 def build_checklist(workflows, forms):
-    agg = {}
+    # Per-workflow, per-code counts (not per-task-name) — the checklist needs to say WHICH workflow
+    # needs the work, not just how many tasks of a given kind exist across the whole environment.
+    wf_items = []
     for w in workflows:
+        counts = {}
         for t in w["tasks"]:
-            key = (t["task_name"], t["app"], t["code"], t["short_recommendation"])
-            agg[key] = agg.get(key, 0) + 1
-    wf_items = [
-        {
-            "key": k[0],
-            "app": k[1],
-            # display app: AGManager -> "AG Manager" (matches the task Interface label); adapter type as-is
-            "app_display": "AG Manager" if k[1] == IAG4_APP else k[1],
-            "code": k[2],
-            "count": c,
-            "recommendation": k[3],
-        }
-        for k, c in agg.items()
-    ]
-    # group by code (CODE_ORDER) then name, so the checklist reads in the same order as the legend
-    wf_items.sort(key=lambda x: (CODE_ORDER.index(x["code"]), str(x["key"]), str(x["app"])))
+            counts[t["code"]] = counts.get(t["code"], 0) + 1
+        for code, count in counts.items():
+            wf_items.append({
+                "code": code,
+                "workflow_name": w["workflow_name"],
+                "workflow_id": w["workflow_id"],
+                "count": count,
+            })
+    # group by code (CODE_ORDER, matches the Recommended Actions legend) then workflow name/id
+    wf_items.sort(key=lambda x: (CODE_ORDER.index(x["code"]), x["workflow_name"], x["workflow_id"] or ""))
     form_items = [
         {"form_name": f["form_name"], "field_key": f["field_key"],
          "bound_endpoint": f["bound_endpoint"], "recommendation": REC_FORM}

--- a/helpers/iag-migration/readiness-report-template.md
+++ b/helpers/iag-migration/readiness-report-template.md
@@ -22,7 +22,7 @@ identify them on the platform. (Scripts/variable names may still use IAG interna
 
 FIXED remediation CODES — the "Recommended action" cell for each is the VERBATIM REC_* constant in
 analyze_iag4.py (CODE_BY_TYPE / REC_BY_CODE); keep both in sync (determinism contract):
-  - WRAP   (collection-or-role task): wrap in a Python script (preferred) or an Ansible playbook; run as a Gateway5 service
+  - WRAP   (collection-or-role task, e.g. itential_cli / itential_set_config): wrap in a Python script or an Ansible playbook and run as a Gateway5 service, or replace with an Inventory Manager send_command/set_config task if that covers the same logic
   - REVIEW (ansible playbook):        likely no code change — review how inventory is handled (Gateway5 has no built-in inventory)
   - ARGS   (python script):           change positional args to named args (--flag / argparse); run as a Gateway5 python-script service
   - INV    (device/group op on the Gateway4 adapter): move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation
@@ -42,9 +42,16 @@ unresolved_children as
 given (sorted). No per-row timestamps.
 
 Workflow location comes from the workflow's `namespace` field (authoritative project membership):
-"Global" when not project-owned, else "«{project_name}» ({project_id})". A stale @id: name prefix
-is NOT project membership — those are Global. Never emit "name unavailable". Location is rendered the
-SAME way everywhere (index Scope/Connector column AND detail heading) — the project id is kept.
+"Global" when not project-owned, else "{project_name} ({project_id})" (plain text — no special
+brackets/quoting around the name). A stale @id: name prefix is NOT project membership — those are
+Global. Never emit "name unavailable". Location is rendered the SAME way everywhere (index
+Scope/Connector column AND detail heading) — the project id is kept.
+
+TOC anchors for the nested Workflows sub-links (see Contents below) are plain GitHub slugs of
+`group.label`: lowercase, drop any character that isn't a letter/digit/space/hyphen (this drops the
+parentheses around the id), then replace spaces with hyphens. E.g. "Arista EOS (66d0da17...)" ->
+"arista-eos-66d0da17...". "Global" -> "global". Since labels are plain text (no «» quoting), this
+is a direct, deterministic slug — compute it the same way every run.
 -->
 
 # Itential Gateway4 → Itential Gateway5 Migration Readiness
@@ -68,9 +75,15 @@ SAME way everywhere (index Scope/Connector column AND detail heading) — the pr
 
 ## Contents
 
+<!-- The Workflows entry (3) nests one sub-link per analysis.json workflow_groups[] entry (project/
+     Global groups, in the same order rendered in the Workflows section) so the reader can jump
+     straight to a project. Anchor = the slug rule above. Do NOT nest down to individual workflows
+     (keeps the TOC compact) — each group's index table below already lists its workflows with IDs. -->
 1. [Summary](#summary)
 2. [Recommended Actions](#recommended-actions)
 3. [Workflows](#workflows)
+   {{#each group}}- [{{group.label}}](#{{slug(group.label)}})
+   {{/each}}
 4. [JSON Forms](#json-forms)
 5. [Scripts, Playbooks & Roles](#scripts-playbooks--roles)
 6. [Inventory](#inventory)
@@ -99,7 +112,7 @@ classification from the task's name and description — **review each** before a
 
 | Code | Applies to (Gateway4 task type) | Recommended action |
 |---|---|---|
-| **WRAP** | Ansible collection-module task or role | wrap in a Python script (preferred) or an Ansible playbook; run as a Gateway5 service |
+| **WRAP** | Ansible collection-module task or role (e.g. `itential_cli`, `itential_set_config`) | wrap in a Python script or an Ansible playbook and run as a Gateway5 service, or replace with an Inventory Manager send_command/set_config task if that covers the same logic |
 | **REVIEW** | Ansible playbook | likely no code change — review how inventory is handled (Gateway5 has no built-in inventory) |
 | **ARGS** | Python script | change positional args to named args (--flag / argparse); run as a Gateway5 python-script service |
 | **INV** | Device/group operation on the Gateway4 adapter | move to the Inventory Manager application; use a device send-command / set-config task instead of the Gateway4 device operation |
@@ -113,7 +126,7 @@ classification from the task's name and description — **review each** before a
 
      For EACH group:
        ### {{group.label}}
-         group.label = "«{project_name}» ({project_id})" for a project, or "Global" for the
+         group.label = "{project_name} ({project_id})" (plain text) for a project, or "Global" for the
          not-in-a-project group. The project/Global identity lives HERE, so it is NOT repeated in the
          per-workflow rows below (no "Scope / Connector" column, no location in the detail heading).
 
@@ -144,6 +157,14 @@ classification from the task's name and description — **review each** before a
            Zero lines → render nothing. Exactly ONE line → inline "**References:** <line>". MORE than
            one → a "**References:**" header then a bullet per line. -->
 {{n_workflows}} workflows reference Gateway4 tasks ({{n_gw4_tasks}} tasks total), grouped by project below (Global workflows last). Each project lists its workflows, then per-workflow task detail and cross-references. The **Rec** column codes are explained in [Recommended Actions](#recommended-actions).
+
+<!-- Workflows Summary — one row per workflow_groups[] entry, straight from group.n_workflows /
+     group.n_tasks (already aggregated by the analyzer — do not recompute). A quick per-project view
+     of how much work is outstanding before diving into the per-group detail below. -->
+| Project / Location | Workflows | Tasks to fix |
+|---|---|---|
+{{#each group}}| {{group.label}} | {{group.n_workflows}} | {{group.n_tasks}} |
+{{/each}}| **Total** | {{n_workflows}} | {{n_gw4_tasks}} |
 
 {{#each group}}
 ### {{group.label}}
@@ -243,12 +264,17 @@ stricter ownership / separation-of-concerns requirements. Team names below are p
      Scripts/Playbooks/Roles, Inventory, General. -->
 ### Workflows
 
-<!-- Self-contained items — each carries its full recommendation text, so no separate legend is
-     needed. checklist.workflows is already sorted by recommendation then name (so identical
-     recommendations sit together). Item: "- [ ] `{{key}}` ({{app_display}}, {{count}} task|tasks) —
-     {{recommendation}}". app_display is "AG Manager" or the adapter type (resolved in analysis.json).
-     Pluralize: "task" if count==1 else "tasks". No codes, no divergence note. -->
-{{#each checklist.workflows}}- [ ] `{{key}}` ({{app_display}}, {{count}} task(s)) — {{recommendation}}
+<!-- Grouped by CODE (WRAP/REVIEW/ARGS/INV, CODE_ORDER — matches the Recommended Actions legend).
+     checklist.workflows is already {code, workflow_name, workflow_id, count} sorted by code then
+     workflow name/id. Render ONE #### heading per code that has items (carries the recommendation
+     text ONCE via REC_BY_CODE — do not repeat it per item), then one line per workflow: "- [ ]
+     `{{workflow_name}}` (`{{workflow_id}}`) — {{count}} task(s)". Skip a code heading entirely if
+     it has no items. -->
+{{#each code in CODE_ORDER}}
+#### {{code}} — {{REC_BY_CODE[code]}}
+
+{{#each checklist.workflows where code==code}}- [ ] `{{workflow_name}}` (`{{workflow_id}}`) — {{count}} task(s)
+{{/each}}
 {{/each}}
 
 ### JSON Forms
@@ -263,7 +289,9 @@ stricter ownership / separation-of-concerns requirements. Team names below are p
 
 ### Inventory
 
-{{#each device}}- [ ] `{{device_name}}` (origin {{origins}}) — {{recommendation}}
+<!-- Simple identification list — device name + origin only, no repeated recommendation text (the
+     single re-homing action is already stated once in the Inventory report section above). -->
+{{#each device}}- [ ] `{{device_name}}` — origin `{{origins}}`
 {{/each}}{{inventory_action}}
 
 ### General


### PR DESCRIPTION
## What changed
Refinements to the `/iag4-to-iag5` skill and its readiness report template based on real-world usage — no new capabilities, just clarity and accuracy fixes to the existing output.

## Motivation
The report was hard to skim at a glance and pointed engineers toward. This cleans up the reading experience and fixes an itential_cli recommendation.

## Changes
- Added a summary section at the top of the report to see scope/counts of workflows/tasks.
- Updated the Table of Contents to include links for projects/workflows.
- Cleaned up the Manual Action Checklist.
- Scoped the skill's goal to report generation only. Removed language that suggested an automatic build step after the report is produced
- Fixed the `itential_cli` recommendation, now correctly points to `send_command`/`set_config` instead

## To Test
Create a working directory and place a .env file in it with your connection information to an IAP instance, then run a prompt like "Am I ready for Gateway5?" or "Use /iag4-to-iag5 to analyze my environment". Confirm the report renders the new summary, TOC links, cleaner checklist, and the corrected recommendation for `itential_cli` tasks.