### PR TITLE
docs(builder-agent): warn about components/add iid collision across calls

### DIFF
--- a/.claude/skills/builder-agent/SKILL.md
+++ b/.claude/skills/builder-agent/SKILL.md
@@ -842,6 +842,14 @@ POST /automation-studio/projects/{projectId}/components/add
 
 **Component types:** `workflow`, `template`, `transformation`, `jsonForm`, `mopCommandTemplate`, `mopAnalyticTemplate`
 
+> **`components/add` called more than once on the same project can corrupt `iid` tracking.** Confirmed on a project created via empty `POST /automation-studio/projects` (not `import`): a first `components/add` call (e.g. 5 components) gets assigned sequential `iid`s, but the project's own `componentIidIndex` can come back reporting a value *lower* than the actual max `iid` just used. A second `components/add` call trusts that stale index as its starting point and assigns new `iid`s that collide with ones from the first call — two different components end up sharing the same `iid`, silently corrupting anything that references components by `iid` (notably `folders[].children[].iid` groupings).
+>
+> **Diagnostic sign:** after adding components in more than one call, `GET` the project and check `components[].iid` for duplicates across different `type`s.
+>
+> **`PATCH` does not fix this.** Sending a corrected `components`/`folders` array with de-duplicated, hand-assigned `iid`s via `PATCH /automation-studio/projects/{projectId}` returns `200`, but the platform recalculates/discards your custom `iid` values server-side — a `GET` right after still shows the same collision. Don't try to patch your way out of it.
+>
+> **Fix — pick one:** (a) batch every component you're adding into a **single** `components/add` call (confirmed reliable — produces clean sequential `iid`s), or (b) rebuild the project from scratch via `projects/import`, embedding each component's full document directly rather than moving in pre-existing standalone assets.
+
 ### Update membership (full replacement)
 
 **Before patching, always ask the engineer:** *"Who else should have access to this project? (usernames or group names)"*


### PR DESCRIPTION
## Summary
- Documents a confirmed platform bug: on a project created via empty `POST /automation-studio/projects` (not `import`), calling `components/add` more than once can produce duplicate `iid`s across calls.
- Root cause: the second call trusts the project's own `componentIidIndex`, which can come back reporting a value lower than the actual max `iid` already assigned by the first call — so the new batch's `iid`s collide with the previous batch's.
- This silently corrupts anything that references components by `iid`, notably `folders[].children[].iid` groupings (a component ends up in the wrong folder, or two components appear to occupy the same slot).
- Also documents that `PATCH /automation-studio/projects/{projectId}` cannot be used to fix this after the fact — the platform recalculates/discards custom `iid` values sent via `PATCH` silently (returns `200`, but a follow-up `GET` shows the collision is still there).
- Gives the two reliable fixes: batch all components into a single `components/add` call, or rebuild the project via `projects/import`.

## Test plan
- [x] Reproduced live on a real Itential Platform instance: first `components/add` call (5 components: template, MOP, 3 forms) returned `componentIidIndex: 5` despite assigning `iid`s 3-7; a second call (3 workflows) used that stale index and produced `iid`s 5-7, colliding with 3 of the jsonForms.
- [x] Confirmed `PATCH` with corrected `iid`/`folders` values returns success but does not actually change the stored `iid`s (verified via `GET` immediately after).
- [x] Confirmed the fix: rebuilding via `projects/import`, then adding remaining components in single batched `components/add` calls, produced clean sequential `iid`s with no collisions.