### PR TITLE
Refactor/rename gw4 to gw5

### DIFF
--- a/.claude/skills/gateway4-to-gateway5/SKILL.md
+++ b/.claude/skills/gateway4-to-gateway5/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: iag4-to-iag5
-description: Assess how ready an environment is to move from Itential Automation Gateway 4 (IAG4) to IAG5. Use for phrases like "am I ready to move to IAG5", "assess my IAG4 to IAG5 migration", "what do I need to change to switch off gateway 4", "scan my workflows for automation gateway usage", "which workflows use IAG4", "IAG4 readiness report", or "evaluate my gateway migration". This skill does NOT perform the migration — it analyzes IAP assets (workflows in and out of projects, JSON forms) and IAG4 assets (scripts, playbooks, roles, inventory), then writes a deterministic markdown guideline of the manual actions the user must take. It is strictly READ-ONLY against IAP and IAG — it never creates, updates, or deletes anything on the platform; its only write is the report in the working directory. It can also run in a LOCAL-FILES-ONLY mode with no API access. The rendered report uses the terms "Itential Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5" (never "IAG"). For actually building IAG5 services, use /iag.
+name: gateway4-to-gateway5
+description: Assess how ready an environment is to move from Itential Automation Gateway 4 (IAG4) to Gateway 5 (IAG5). Use for phrases like "am I ready to move to IAG5", "assess my IAG4 to IAG5 migration", "what do I need to change to switch off gateway 4", "scan my workflows for automation gateway usage", "which workflows use IAG4", "IAG4 readiness report", or "evaluate my gateway migration". This skill does NOT perform the migration — it analyzes IAP assets (workflows in and out of projects, JSON forms) and IAG4 assets (scripts, playbooks, roles, inventory), then writes a deterministic markdown guideline of the manual actions the user must take. It is strictly READ-ONLY against IAP and IAG — it never creates, updates, or deletes anything on the platform; its only write is the report in the working directory. It can also run in a LOCAL-FILES-ONLY mode with no API access. The rendered report uses the terms "Itential Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5" (never "IAG"). For actually building IAG5 services, use /iag.
 argument-hint: "[working-directory]"
 ---
 
-# IAG4 → IAG5 Readiness Assessment (iag4-to-iag5)
+# Gateway4-IAG4 → Gateway4-IAG5 Readiness Assessment (gateway4-to-gateway5)
 
 **Path:** Standalone analysis — not part of the delivery lifecycle. Sibling to `/iag`.
 **Owns:** Identifying IAG4 usage across IAP + IAG4 assets and reporting the manual migration steps.
-**Produces:** `<working-dir>/iag4-to-iag5-readiness.md` — one deterministic markdown report. All
+**Produces:** `<working-dir>/gateway4-to-gateway5-readiness.md` — one deterministic markdown report. All
 pulled JSON, the auth cache, and scratch files go under `<working-dir>/tmp/` — never the
 working-dir root. Only the report lives in the root.
 
@@ -98,8 +98,8 @@ authoritative reference for building the IAG5 service, the `--property_name` nam
 ## Determinism contract
 
 Same inputs ⇒ identical report. Enforce:
-- Fixed section set/order — from `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-template.md`. Never drop a section; empty sections render `No IAG4 references found.`
-- **The workflow + JSON-form findings are produced by `analyze_iag4.py`** (Step 2), not by the
+- Fixed section set/order — from `${CLAUDE_PLUGIN_ROOT}/../../../helpers/gateway-migration/readiness-report-template.md`. Never drop a section; empty sections render `No Gateway4 references found.`
+- **The workflow + JSON-form findings are produced by `analyze_gateway4.py`** (Step 2), not by the
   model — that script owns their determinism (detection, classification, sorting, aggregation).
   Its recommendation strings MUST stay byte-identical to the template. Render those sections
   verbatim from `tmp/analysis.json`; only the scripts + inventory sections are model-authored.
@@ -305,11 +305,11 @@ chosen in Step 0:
 
 ```bash
 # live scoped run:
-python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py \
+python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/gateway-migration/analyze_gateway4.py \
   --tmp <working-dir>/tmp \
   { --projects <id,id>  |  --workflows "Name A;Name B"  |  --all }
 # local-files-only run (no API): add --local (and --local-dir if the JSON isn't in tmp/):
-python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py \
+python3 -B ${CLAUDE_PLUGIN_ROOT}/../../../helpers/gateway-migration/analyze_gateway4.py \
   --tmp <working-dir>/tmp --local --local-dir <dir-of-workflow-json> \
   { --projects <id,id>  |  --workflows "Name A;Name B"  |  --all }
 # writes <working-dir>/tmp/analysis.json
@@ -459,8 +459,8 @@ Manager mapping guidance comes later.)
 
 ## Step 6 — Write the report
 
-Fill `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-template.md` and write
-`<working-dir>/iag4-to-iag5-readiness.md` (the report is the **only** file in the working-dir
+Fill `${CLAUDE_PLUGIN_ROOT}/../../../helpers/gateway-migration/readiness-report-template.md` and write
+`<working-dir>/gateway4-to-gateway5-readiness.md` (the report is the **only** file in the working-dir
 root — all pulled JSON and scratch stay in `tmp/`).
 
 **Recommendations via short CODES + one static legend.** Each Gateway4 task carries a short
@@ -494,8 +494,8 @@ Gateway4"/"Gateway4" and "Itential Gateway5"/"Gateway5". Keep literal API/app na
 identify them on the platform. When you fill the template: (1) substitute every `{{placeholder}}`,
 (2) **strip all `<!-- … -->` guidance comments** (they are for you, not the report), and (3) as a
 final self-check, confirm the written report contains no case-insensitive "iag" —
-`grep -i iag <working-dir>/iag4-to-iag5-readiness.md` must return nothing (the filename itself is not
-part of the file's content). If it matches, fix the wording before telling the user it's done.
+`grep -i iag <working-dir>/gateway4-to-gateway5-readiness.md` must return nothing. If it matches,
+fix the wording before telling the user it's done.
 
 **Render the deterministic sections straight from `tmp/analysis.json`** — do not recompute:
 - **Header** = a two-column key/value table (Generated, Working directory, Mode ← `mode`, Platform
@@ -626,12 +626,12 @@ they will say so and start a new, separate request (e.g. `/iag`); this skill nev
 - **`--all` paginates; scoped pulls don't.** The `workflows` list caps at 100/page — only the
   `--all` bulk pull loops on `total`. Scoped runs pull via project export / by-name instead.
 - **Static dropdowns are not a concern.** Only `binding: true` REST-bound dropdowns can point at Gateway4.
-- **The script owns workflow + form classification — never hand-classify.** `analyze_iag4.py`
+- **The script owns workflow + form classification — never hand-classify.** `analyze_gateway4.py`
   emits `python-script` as the default and computes interface/refs/closure. Only *unresolved
   identifiers* (empty `identifiers` block — Step 1b), an *unclear `.env` purpose*, or the *Step 0
   working-dir/scope/source questions* warrant a question — never the per-task approach or the source.
 - **Keep the recommendation strings in sync.** They live once as constants in
-  `helpers/iag-migration/analyze_iag4.py` and must match `readiness-report-template.md`
+  `helpers/gateway-migration/analyze_gateway4.py` and must match `readiness-report-template.md`
   verbatim. Change them in both places or determinism breaks.
 - **Ask working dir + scope + data source first.** If not supplied, ask up front (Step 0). Warn that
   `--all` can overflow a small model's context on large platforms.
@@ -646,5 +646,5 @@ they will say so and start a new, separate request (e.g. `/iag`); this skill nev
 - `/itential-inventory` — Inventory Manager, the IAG5 replacement for gateway inventory.
 - `/itential-json-forms` — REST-bound dropdown structure and `bindingSchema`.
 - `/explore` — auth + IAP pull mechanics reused in Step 1.
-- Analysis script: `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/analyze_iag4.py` (Step 2, deterministic).
-- Template: `${CLAUDE_PLUGIN_ROOT}/../../../helpers/iag-migration/readiness-report-template.md`.
+- Analysis script: `${CLAUDE_PLUGIN_ROOT}/../../../helpers/gateway-migration/analyze_gateway4.py` (Step 2, deterministic).
+- Template: `${CLAUDE_PLUGIN_ROOT}/../../../helpers/gateway-migration/readiness-report-template.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Each skill owns a domain. **Invoke the skill using the Skill tool before working
 | `/builder-agent` | **Builder Agent** | Build all assets, test each component individually. Runs after Design. |
 | `/qa-agent` | **QA Agent** | Acceptance testing against the approved acceptance criteria + as-built record. Runs after Build — last technical stage before customer sign-off. |
 | `/iag` | — | Automation Gateway: IAG services (Python, Ansible, OpenTofu). |
-| `/iag4-to-iag5` | — | Assess IAG4→IAG5 migration readiness; identify IAG4 usage and produce a manual-action guideline. Analysis only, no migration. |
+| `/gateway4-to-gateway5` | — | Assess Gateway4→Gateway5 migration readiness; identify Gateway4/IAG4 usage and produce a manual-action guideline. Analysis only, no migration. |
 | `/flowagent` | — | AI Agents: configure LLM providers, tools, and agent sessions. |
 | `/itential-mop` | — | Command templates with validation rules. |
 | `/itential-devices` | — | Devices, backups, diffs, device groups. |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See [`docs/quickstart.md`](docs/quickstart.md) for the full setup and first deli
 "I want to explore what's available on my platform"
 → /itential-builder:explore
 
-"Am I ready to move from IAG4 to IAG5?"
+"Am I ready to move from Gateway 4 (IAG4) to Gateway 5 (IAG5)?"
 → /itential-builder:gateway4-to-gateway5
 
 "Help me build a golden config for my devices and run compliance"

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Spec-driven infrastructure automation and orchestration — delivered by AI agen
 ## Table of Contents
 
 - [Itential — Agentic Builder Skills](#itential--agentic-builder-skills)
-  - [Table of Contents](#table-of-contents)
-  - [Prerequisites](#prerequisites)
-  - [Getting Started](#getting-started)
-  - [How to Use It](#how-to-use-it)
-  - [Skills](#skills)
-  - [Spec Library](#spec-library)
-  - [Demo Specs](#demo-specs)
-  - [Docs](#docs)
-  - [Contributing](#contributing)
-  - [Support](#support)
-  - [License](#license)
+- [Table of Contents](#table-of-contents)
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+- [How to Use It](#how-to-use-it)
+- [Skills](#skills)
+- [Spec Library](#spec-library)
+- [Demo Specs](#demo-specs)
+- [Docs](#docs)
+- [Contributing](#contributing)
+- [Support](#support)
+- [License](#license)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Spec-driven infrastructure automation and orchestration — delivered by AI agen
 ## Table of Contents
 
 - [Itential — Agentic Builder Skills](#itential--agentic-builder-skills)
-- [Table of Contents](#table-of-contents)
-- [Prerequisites](#prerequisites)
-- [Getting Started](#getting-started)
-- [How to Use It](#how-to-use-it)
-- [Skills](#skills)
-- [Spec Library](#spec-library)
-- [Demo Specs](#demo-specs)
-- [Docs](#docs)
-- [Contributing](#contributing)
-- [Support](#support)
-- [License](#license)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Getting Started](#getting-started)
+  - [How to Use It](#how-to-use-it)
+  - [Skills](#skills)
+  - [Spec Library](#spec-library)
+  - [Demo Specs](#demo-specs)
+  - [Docs](#docs)
+  - [Contributing](#contributing)
+  - [Support](#support)
+  - [License](#license)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See [`docs/quickstart.md`](docs/quickstart.md) for the full setup and first deli
 → /itential-builder:explore
 
 "Am I ready to move from IAG4 to IAG5?"
-→ /itential-builder:iag4-to-iag5
+→ /itential-builder:gateway4-to-gateway5
 
 "Help me build a golden config for my devices and run compliance"
 → /itential-builder:itential-golden-config
@@ -151,7 +151,7 @@ See [`docs/quickstart.md`](docs/quickstart.md) for the full setup and first deli
 |-------|-------------|
 | `/itential-builder:flowagent` | Creates and runs AI agents on the Itential Platform. Configures LLM providers, registers tools (adapters, workflows, IAG services), and runs agent sessions. Use when building or operating Flow AI agents. |
 | `/itential-builder:iag` | Builds and runs IAG 5 services — Python scripts, Ansible playbooks, OpenTofu plans. Manages YAML service definitions, imports via `iagctl`, and calls services from Itential workflows via GatewayManager. |
-| `/itential-builder:iag4-to-iag5` | Assesses readiness to migrate from IAG4 to IAG5. Scans workflows, JSON forms, scripts, playbooks, and inventory for IAG4 usage (`AGManager` / `automation_gateway`). Produces a deterministic markdown readiness report with a manual-action checklist. Read-only — never modifies the platform. For building IAG5 services after the assessment, use `/iag`. |
+| `/itential-builder:gateway4-to-gateway5` | Assesses readiness to migrate from Gateway4-IAG4 to Gateway5-IAG5. Scans workflows, JSON forms, scripts, playbooks, and inventory for Gateway4-IAG4 usage (`AGManager` / `automation_gateway`). Produces a deterministic markdown readiness report with a manual-action checklist. Read-only — never modifies the platform. For building Gateway5-IAG5 services after the assessment, use `/iag`. |
 | `/itential-builder:itential-mop` | Builds Method of Procedure command templates with variable substitution and validation rules. Runs CLI pre-checks and post-checks against devices, and uses analytic templates for before/after config comparison. |
 | `/itential-builder:itential-devices` | Manages network devices in Itential Configuration Manager — onboard devices, take config backups, diff configurations, organize device groups, and apply device templates. |
 | `/itential-builder:itential-golden-config` | Builds golden config trees and node-level config specs that define the expected configuration standard for your devices. Runs compliance plans, grades results, and generates remediation configs for violations. |

--- a/helpers/gateway-migration/analyze_gateway4.py
+++ b/helpers/gateway-migration/analyze_gateway4.py
@@ -2,7 +2,7 @@
 import sys
 sys.dont_write_bytecode = True
 
-"""Deterministic IAG4 usage analysis for the /iag4-to-iag5 skill.
+"""Deterministic Gateway4-IAG4 usage analysis for the /gateway4-to-gateway5 skill.
 
 Pure analysis over already-pulled data in a working directory's tmp/ folder. Reads
 wf_all.ndjson, apps.json, adapters.json and json-forms.json; resolves the IAG4
@@ -14,7 +14,7 @@ It never touches IAP/IAG and never re-pulls data. Scripts + inventory analysis s
 the skill's AI. The report is rendered by the skill from this JSON.
 
 The recommendation strings below are the single source of truth and MUST stay identical to
-helpers/iag-migration/readiness-report-template.md.
+helpers/gateway-migration/readiness-report-template.md.
 """
 
 import argparse

--- a/helpers/gateway-migration/readiness-report-template.md
+++ b/helpers/gateway-migration/readiness-report-template.md
@@ -1,6 +1,6 @@
 <!--
 Gateway4 → Gateway5 Readiness Report — FIXED TEMPLATE.
-The iag4-to-iag5 skill fills this in. Keep section order and headings identical every run so
+The gateway4-to-gateway5 skill fills this in. Keep section order and headings identical every run so
 the same inputs always produce a byte-identical report (aside from the header metadata line).
 Canonical section order (also the Table of Contents at the top): Summary, Workflows, JSON Forms,
 Scripts/Playbooks & Roles, Inventory, Recommended Repository Structure, Manual Action Checklist.
@@ -21,7 +21,7 @@ WORDING RULE (hard): the rendered report must NOT contain "iag", "IAG4", or "IAG
 identify them on the platform. (Scripts/variable names may still use IAG internally — never rendered.)
 
 FIXED remediation CODES — the "Recommended action" cell for each is the VERBATIM REC_* constant in
-analyze_iag4.py (CODE_BY_TYPE / REC_BY_CODE); keep both in sync (determinism contract):
+analyze_gateway4.py (CODE_BY_TYPE / REC_BY_CODE); keep both in sync (determinism contract):
   - WRAP   (collection-or-role task, e.g. itential_cli / itential_set_config): wrap in a Python script or an Ansible playbook and run as a Gateway5 service, or replace with an Inventory Manager send_command/set_config task if that covers the same logic
   - REVIEW (ansible playbook):        likely no code change — review how inventory is handled (Gateway5 has no built-in inventory)
   - ARGS   (python script):           change positional args to named args (--flag / argparse); run as a Gateway5 python-script service
@@ -35,7 +35,7 @@ Other fixed strings (keep in sync too):
   - role asset:             wrap in a playbook or Python script; place in a git repo
   - playbook asset:         place in a git repo; no code change
 
-Sort rules (analyze_iag4.py already applies them — render straight through): workflows by name (asc),
+Sort rules (analyze_gateway4.py already applies them — render straight through): workflows by name (asc),
 then project id, then workflow id; tasks within a workflow by task id (asc); checklist by code
 (WRAP, REVIEW, ARGS, INV) then name; forms by name; assets by filename; devices by name;
 unresolved_children as
@@ -105,7 +105,7 @@ is a direct, deterministic slug — compute it the same way every run.
 ## Recommended Actions
 
 <!-- STATIC legend, always rendered verbatim. The "Recommended action" cells are the VERBATIM
-     REC_WRAP / REC_REVIEW / REC_ARGS / REC_INV constants from analyze_iag4.py — do not reword
+     REC_WRAP / REC_REVIEW / REC_ARGS / REC_INV constants from analyze_gateway4.py — do not reword
      (determinism sync). Each Gateway4 task in Workflows is tagged with one of these codes. -->
 Each Gateway4 task in the Workflows section is tagged with one short code. Codes are a best-effort
 classification from the task's name and description — **review each** before acting.


### PR DESCRIPTION
## Description
Renames the `/iag4-to-iag5` skill to `/gateway4-to-gateway5` across the skill, helpers, router, and docs.

## What it does
- Renames the skill directory, `gateway4-to-gateway5`.
- Renames the report output → `<working-dir>/gateway4-to-gateway5-readiness.md`.
- Renames the helper folder `helpers/iag-migration/` → `helpers/gateway-migration/` and the analysis script `analyze_iag4.py` → `analyze_gateway4.py`, and updates every path/reference to them.
- Updates the skill router (`AGENTS.md`) and platform skills table (`README.md`) to the new name.

**Rename only — no behavior change.**

## Files changed
- `.claude/skills/gateway4-to-gateway5/SKILL.md` — renamed from `iag4-to-iag5/`; name, title, and paths updated.
- `helpers/gateway-migration/analyze_gateway4.py` — renamed from `iag-migration/analyze_iag4.py`.
- `helpers/gateway-migration/readiness-report-template.md` — moved; script references updated.
- `AGENTS.md` — skill router entry renamed.
- `README.md` — platform skills table entry renamed.

  ## To Test
  Invoke the skill with `/gateway4-to-gateway5` (or a prompt like "Am I ready for Gateway5?"), point it at a working directory containing a `.env` for an IAP instance, and confirm it runs the analyzer and writes `gateway4-to-gateway5-readiness.md`. .