### PR TITLE
docs: update maintainer listing, remove departed maintainer reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -386,7 +386,7 @@ Example: "Use Google-style docstrings with Args, Returns, and Raises sections"
 - **Documentation**: Check the README.md and AGENTS.md files
 - **Issues**: Search existing issues for similar problems
 - **Discussions**: Use GitHub Discussions for questions
-- **Maintainer**: [@wcollins](https://github.com/wcollins)
+- **Maintainer**: [@keepithuman](https://github.com/keepithuman)
 
 ### Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 - **Bug Reports**: [Open an issue](https://github.com/itential/builder-skills/issues/new)
 - **Questions**: [Start a discussion](https://github.com/itential/builder-skills/discussions)
 - **Lead Maintainer**: [@keepithuman](https://github.com/keepithuman)
-- **Maintainer**: [@wcollins](https://github.com/wcollins)
 
 ---
 


### PR DESCRIPTION
## Summary
- @wcollins is no longer with the company.
- `README.md`: removes the redundant `**Maintainer**: [@wcollins]` line — `**Lead Maintainer**: [@keepithuman]` already covers current maintainership, so this avoided listing the same person twice under two titles.
- `CONTRIBUTING.md`: updates the `**Maintainer**` contact from `@wcollins` to `@keepithuman`.

## Test plan
- [x] Confirmed no other references to `wcollins` remain anywhere in the repo (`grep -rn wcollins`).