### PR TITLE
chore: add auto-versioning on merge via branch-name-based labeling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,37 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Features'
+    labels: ['feature']
+  - title: '🐛 Bug Fixes'
+    labels: ['fix']
+  - title: '🧰 Refactoring'
+    labels: ['refactor']
+  - title: '🧹 Chores'
+    labels: ['chore']
+  - title: '📝 Documentation'
+    labels: ['documentation']
+
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels: ['breaking', 'breaking-change']
+  minor:
+    labels: ['feature']
+  patch:
+    labels: ['fix', 'refactor']
+  default: patch
+
+# docs/ and chore/ branches are auto-labeled with skip-changelog by pr-labeler.yml —
+# excluded entirely from both release notes and version resolution, matching the
+# "docs/chore = no bump" policy in CONTRIBUTING.md.
+exclude-labels:
+  - 'skip-changelog'
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,9 +12,18 @@ name: PR Labeler
 #
 # major/breaking bumps are NEVER inferred here — that requires a human to apply the
 # `breaking-change` label explicitly. See "what counts as breaking" in CONTRIBUTING.md.
+#
+# Uses pull_request_target, not pull_request: every PR in this repo comes from a fork
+# (see AGENTS.md/CONTRIBUTING.md's fork-only workflow), and the default GITHUB_TOKEN for
+# a fork-triggered `pull_request` event is read-only regardless of the `permissions:`
+# declared below — confirmed live (PR #97 failed with "Resource not accessible by
+# integration" until this was switched). `pull_request_target` runs with the base repo's
+# token permissions instead. This is safe here specifically because the job below never
+# checks out the PR's code — it only reads event metadata (PR number, branch name) — so
+# a malicious fork PR can't get its own code to run with elevated permissions.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     branches: [main]
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,61 @@
+name: PR Labeler
+
+# Auto-labels a PR from its branch-name prefix so Release Drafter (release-drafter.yml)
+# can resolve the next version without anyone applying labels by hand.
+#
+# Mapping (see .github/release-drafter.yml and CONTRIBUTING.md):
+#   feature/  -> feature   (minor)
+#   fix/      -> fix       (patch)
+#   refactor/ -> refactor  (patch)
+#   docs/     -> documentation + skip-changelog (excluded from versioning)
+#   chore/    -> chore + skip-changelog         (excluded from versioning)
+#
+# major/breaking bumps are NEVER inferred here — that requires a human to apply the
+# `breaking-change` label explicitly. See "what counts as breaking" in CONTRIBUTING.md.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-by-branch-prefix:
+    name: Label by branch prefix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label from branch prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          prefix="${BRANCH_NAME%%/*}"
+
+          case "$prefix" in
+            feature)
+              labels="feature"
+              ;;
+            fix)
+              labels="fix"
+              ;;
+            refactor)
+              labels="refactor"
+              ;;
+            docs)
+              labels="documentation,skip-changelog"
+              ;;
+            chore)
+              labels="chore,skip-changelog"
+              ;;
+            *)
+              echo "Branch prefix '$prefix' has no labeler mapping — skipping."
+              exit 0
+              ;;
+          esac
+
+          echo "Applying labels: $labels"
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$labels"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+# Maintains a draft GitHub Release that accumulates notes from merged PRs and computes
+# the next semver tag from their labels (applied by pr-labeler.yml, or manually for
+# breaking-change). Publishing the release (and its tag) is a manual, deliberate step —
+# this workflow only keeps the draft current.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  update-draft-release:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,83 @@
+name: Version Bump
+
+# After a PR merges to main, bumps .claude-plugin/plugin.json and marketplace.json to
+# stay in sync with the version Release Drafter will resolve for the next release.
+#
+# Bump size comes from the merged PR's labels (applied by pr-labeler.yml, or manually
+# for breaking-change):
+#   breaking-change / breaking -> major
+#   feature                    -> minor
+#   fix / refactor             -> patch
+#   documentation / chore / skip-changelog / no matching label -> no bump
+#
+# PREREQUISITE: this workflow pushes a commit directly to main, which requires an
+# exemption from the branch-protection rule that otherwise blocks direct pushes
+# (the same rule that enforces the fork-only PR workflow for everything else in this
+# repo). Add the actor running this workflow — the default GITHUB_TOKEN acts as
+# "github-actions[bot]" — to the branch protection ruleset's bypass list, or replace
+# GITHUB_TOKEN below with a PAT/App token that already has bypass rights, before this
+# workflow can actually commit. Until that's configured, this job will fail at the
+# push step with a protected-branch rejection — it will not silently do nothing.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  bump-version:
+    name: Bump plugin version
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'chore: bump version to')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine merged PR number
+        id: pr
+        run: |
+          number=$(git log -1 --format=%s | grep -oP '\(#\K[0-9]+(?=\)$)' || true)
+          if [[ -z "$number" ]]; then
+            echo "No PR number found in commit subject — not a squash-merged PR, skipping."
+            echo "number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=$number" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine bump type from PR labels
+        id: bump
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          labels=$(gh pr view "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          echo "PR labels: $labels"
+
+          if grep -qE '^(breaking|breaking-change)$' <<< "$labels"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif grep -qE '^skip-changelog$' <<< "$labels"; then
+            echo "type=" >> "$GITHUB_OUTPUT"
+          elif grep -qE '^feature$' <<< "$labels"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          elif grep -qE '^(fix|refactor)$' <<< "$labels"; then
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          else
+            echo "No version-impacting label found — skipping bump."
+            echo "type=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump manifest files and commit
+        if: steps.bump.outputs.type != ''
+        run: |
+          new_version=$(python3 scripts/bump_version.py --bump "${{ steps.bump.outputs.type }}")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore: bump version to v${new_version} (#${{ steps.pr.outputs.number }})"
+          git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -100,16 +100,18 @@ evals/workspace/
 !.claude/skills/*/custom/dev/.gitkeep
 
 # =============================================================================
+# Python (scripts/)
+# =============================================================================
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+
+# =============================================================================
 # MAINTAINER: Add language-specific patterns below
 # =============================================================================
 # Examples:
-#
-# Python:
-#   __pycache__/
-#   *.py[cod]
-#   .venv/
-#   venv/
-#   .pytest_cache/
 #
 # Node.js:
 #   node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,32 +235,23 @@ Brief description of what this PR does.
 Closes #123
 ```
 
-## Pull Request Labels
+## Pull Request Labels and Versioning
 
-This project uses Release Drafter to automatically generate release notes. Please apply appropriate labels to your pull requests:
+This project uses [Release Drafter](https://github.com/release-drafter/release-drafter) (`.github/release-drafter.yml`) to maintain a draft release with computed release notes and the next semver version, and a companion workflow (`.github/workflows/version-bump.yml`) that keeps `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` in sync with that version after merge. Publishing the draft release itself is still a manual, deliberate step.
 
-### Change Type Labels
-- `feature`, `enhancement` - New features and enhancements
-- `fix`, `bug`, `bugfix` - Bug fixes and corrections
-- `chore`, `dependencies`, `refactor` - Maintenance, dependency updates, and refactoring
-- `documentation`, `docs` - Documentation changes
-- `security` - Security fixes and improvements
-- `breaking`, `breaking-change` - Breaking changes that require major version bump
+**Labels are applied automatically from your branch name** by `.github/workflows/pr-labeler.yml` — you don't need to apply them yourself for the common cases:
 
-### Version Impact Labels
-- `major` - Breaking changes (increments major version)
-- `minor` - New features (increments minor version)
-- `patch` - Bug fixes and maintenance (increments patch version)
+| Branch prefix | Label(s) applied | Version impact |
+|---|---|---|
+| `feature/` | `feature` | minor |
+| `fix/` | `fix` | patch |
+| `refactor/` | `refactor` | patch |
+| `docs/` | `documentation`, `skip-changelog` | none — excluded from versioning |
+| `chore/` | `chore`, `skip-changelog` | none — excluded from versioning |
 
-### Auto-Labeling
-The Release Drafter will automatically apply labels based on:
-- **Branch names**: `feature/`, `fix/`, `chore/` prefixes
-- **File changes**: Documentation files, dependency files
-- **PR titles**: Keywords like "feat", "fix", "chore"
+**Major version bumps are never inferred automatically** — apply the `breaking-change` label yourself when a change would break an existing consumer's setup. For this repo that means things like renaming or removing a skill, changing a script's CLI (`scripts/platform_pull.py`, `scripts/use_case_init.py`), or changing the `custom/org/team/dev` customization-layer contract. Clarifying or correcting existing skill guidance — even a large rewrite — is not breaking on its own; it's `docs`/`fix` at most.
 
-### Special Labels
-- `skip-changelog` - Exclude from release notes
-- `duplicate`, `question`, `invalid`, `wontfix` - Issues that don't represent changes
+**Prerequisite for the version-bump workflow:** it pushes a commit directly to `main` to update the manifest files, which requires an exemption from the branch-protection rule that otherwise blocks direct pushes to `main` (the same rule enforcing the fork-only PR workflow for everything else here). A repo admin needs to add the workflow's actor to the branch protection ruleset's bypass list before this automation can actually commit — see the comment at the top of `version-bump.yml`.
 
 ## Testing
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Bump the plugin version across .claude-plugin/plugin.json and marketplace.json.
+
+Used by .github/workflows/version-bump.yml after a PR merges to main. Not meant to be
+run against a dirty working tree — reads the current version from plugin.json, computes
+the next semver value for the given bump type, and writes it back to both manifest files
+so they can never drift out of sync with each other.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+
+def bump(version: str, kind: str) -> str:
+    major, minor, patch = (int(part) for part in version.split("."))
+    if kind == "major":
+        return f"{major + 1}.0.0"
+    if kind == "minor":
+        return f"{major}.{minor + 1}.0"
+    if kind == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ValueError(f"Unknown bump kind: {kind}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bump", required=True, choices=["major", "minor", "patch"])
+    args = parser.parse_args()
+
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    current_version = plugin["version"]
+    new_version = bump(current_version, args.bump)
+
+    plugin["version"] = new_version
+    PLUGIN_JSON.write_text(json.dumps(plugin, indent=2) + "\n")
+
+    marketplace = json.loads(MARKETPLACE_JSON.read_text())
+    marketplace["metadata"]["version"] = new_version
+    for entry in marketplace.get("plugins", []):
+        entry["version"] = new_version
+    MARKETPLACE_JSON.write_text(json.dumps(marketplace, indent=2) + "\n")
+
+    print(f"{current_version} -> {new_version}", file=sys.stderr)
+    print(new_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

CONTRIBUTING.md already described a Release Drafter setup, but it was never actually implemented — no `.github/release-drafter.yml`, no labeler, no version-bump automation existed. This wires up what was described, and keeps `.claude-plugin/plugin.json`/`marketplace.json` in sync with it.

## How it works

- **`pr-labeler.yml`** — auto-applies a label from the PR's branch-name prefix so contributors don't need to label PRs by hand for the common cases:

  | Branch prefix | Label(s) | Version impact |
  |---|---|---|
  | `feature/` | `feature` | minor |
  | `fix/` | `fix` | patch |
  | `refactor/` | `refactor` | patch |
  | `docs/` | `documentation`, `skip-changelog` | none |
  | `chore/` | `chore`, `skip-changelog` | none |

  **Major/breaking bumps are never inferred from a branch name** — there's no `breaking/` prefix in this repo's branch-naming convention, and "is this breaking" requires human judgment a script can't safely make. Apply the `breaking-change` label yourself when it applies (skill renamed/removed, script CLI changed, customization-layer contract changed) — see the updated CONTRIBUTING.md section for what counts.

- **`release-drafter.yml`** — maintains a draft GitHub Release with computed notes + next version from merged PR labels. Publishing it is still manual.

- **`version-bump.yml`** — after merge, reads the merged PR's labels and bumps `plugin.json`/`marketplace.json` to match, via `scripts/bump_version.py` (tested locally against copies of the real manifest files: 1.6.0 → 1.7.0 for a minor bump, both files updated consistently).

## Prerequisite (not done in this PR)

`version-bump.yml` pushes a commit directly to `main`, which needs an exemption from the branch-protection rule that otherwise blocks direct pushes — the same rule enforcing the fork-only PR workflow everywhere else in this repo. A repo admin needs to add the workflow's actor to the branch protection bypass list before it can actually commit; documented at the top of the workflow file and in CONTRIBUTING.md. Until that's configured, the workflow will fail loudly at the push step rather than silently no-op.

## Also included

- Created the labels this depends on (`feature`, `fix`, `refactor`, `chore`, `skip-changelog`, `breaking-change`) on `itential/builder-skills` — none of them existed.
- Activated the Python `.gitignore` section (was a commented-out example; this repo now ships a real Python script for the version bump, in addition to the existing `scripts/platform_pull.py`/`use_case_init.py`).
- Rewrote the CONTRIBUTING.md "Pull Request Labels" section to describe what's actually implemented instead of the previous aspirational text.

## Security note (found, not fixed here)

Running `actionlint` while validating these new workflows also flagged a pre-existing script-injection risk in `pr-compliance.yml` (`github.head_ref` interpolated directly into a shell script at line 14) — same class of issue I fixed in `pr-labeler.yml` while writing it. Left out of this PR since it's unrelated to versioning; happy to open a separate one-line fix if useful.

## Test plan

- [x] All new/changed YAML validated (`python3 -c "import yaml; ..."` on every file)
- [x] All new workflows pass `actionlint` cleanly (found and fixed one script-injection issue in `pr-labeler.yml` before opening this PR)
- [x] `scripts/bump_version.py` tested against copies of the real manifest files — confirmed both `plugin.json` and `marketplace.json` (including the nested `plugins[0].version`) update consistently
- [x] Confirmed merged PRs in this repo's history consistently carry the `(#NNN)` squash-merge suffix the version-bump workflow parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)